### PR TITLE
store: UpdateEnvironment: do not set auth URL to empty string if request omits it

### DIFF
--- a/internal/store/environments.go
+++ b/internal/store/environments.go
@@ -110,11 +110,16 @@ func (s *Store) UpdateEnvironment(ctx context.Context, req *ssoreadyv1.UpdateEnv
 		return nil, err
 	}
 
+	var authURL *string
+	if req.Environment.AuthUrl != "" {
+		authURL = &req.Environment.AuthUrl
+	}
+
 	qEnv, err := q.UpdateEnvironment(ctx, queries.UpdateEnvironmentParams{
 		ID:          id,
 		DisplayName: &req.Environment.DisplayName,
 		RedirectUrl: &req.Environment.RedirectUrl,
-		AuthUrl:     &req.Environment.AuthUrl,
+		AuthUrl:     authURL,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR prevents users from setting an env's auth URL to the empty string. Instead, the column will be set to null, in which case the default global auth URL can take effect.