### PR TITLE
saml: initiate: truncate IssueInstant to milliseconds

### DIFF
--- a/internal/saml/init.go
+++ b/internal/saml/init.go
@@ -22,7 +22,7 @@ func Init(req *InitRequest) *InitResponse {
 	var samlReq samlRequest
 	samlReq.ID = req.RequestID
 	samlReq.Version = "2.0"
-	samlReq.IssueInstant = req.Now.UTC()
+	samlReq.IssueInstant = req.Now.UTC().Truncate(time.Millisecond)
 	samlReq.Issuer.Name = req.SPEntityID
 	samlReqData, err := xml.Marshal(samlReq)
 


### PR DESCRIPTION
We're seeing an issue where Microsoft Entra IDP-initiated flows fail with:

> IssueInstant needs to be a dateTime

Based on https://learn.microsoft.com/en-us/entra/identity-platform/single-sign-on-saml-protocol#authnrequest:

> This is a DateTime string with a UTC value and [round-trip format ("o")](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). Microsoft Entra ID expects a DateTime value of this type, but doesn't evaluate or use the value.

That round-trip format has this documented example:

```
2009-06-15T13:45:30.0000000Z
```

Our offending timestamp is:

```
2024-05-28T18:59:54.133923346Z
```

The issue seems to be that we provide too many digits of precision. This issue was not caught locally because my computer does not have as much clock precision as the production environment.

The fix is to simply truncate to the closest millisecond. No greater amount of precision appears to be of any use.