### PR TITLE
Expire SAML access tokens on use, and only store their SHA256

### DIFF
--- a/app/src/pages/ViewSAMLFlowPage.tsx
+++ b/app/src/pages/ViewSAMLFlowPage.tsx
@@ -301,10 +301,6 @@ export function ViewSAMLFlowPage() {
                     />
                   </code>
                 </div>
-
-                <div className="text-xs font-mono bg-gray-100 py-1 px-2 rounded-sm max-w-full overflow-auto">
-                  {samlFlow.appRedirectUrl}
-                </div>
               </div>
             </Card>
           )}

--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -278,12 +278,5 @@ func (s *Service) samlAcs(w http.ResponseWriter, r *http.Request) {
 	redirectURL.RawQuery = redirectQuery.Encode()
 	redirect := redirectURL.String()
 
-	if err := s.Store.AuthUpdateAppRedirectURL(ctx, &store.AuthUpdateAppRedirectURLRequest{
-		SAMLFlowID:     createSAMLLoginRes.SAMLFlowID,
-		AppRedirectURL: redirect,
-	}); err != nil {
-		panic(err)
-	}
-
 	http.Redirect(w, r, redirect, http.StatusSeeOther)
 }

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -152,6 +152,7 @@ type SamlFlow struct {
 	ErrorEmailOutsideOrganizationDomains *string
 	Status                               SamlFlowStatus
 	ErrorUnsignedAssertion               bool
+	AccessCodeSha256                     []byte
 }
 
 type SchemaMigration struct {

--- a/internal/store/saml.go
+++ b/internal/store/saml.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -124,12 +125,12 @@ func (s *Store) RedeemSAMLAccessCode(ctx context.Context, req *ssoreadyv1.Redeem
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("bad saml_access_code: %w", err))
 	}
 
-	samlAccessCodeUUID := uuid.UUID(samlAccessCode) // can't do &uuid.UUID(...) in one go, so break this out
+	samlAccessCodeSHA := sha256.Sum256(samlAccessCode[:])
 
 	samlAccessTokenData, err := q.GetSAMLAccessCodeData(ctx, queries.GetSAMLAccessCodeDataParams{
 		AppOrganizationID: apikeyauth.AppOrgID(ctx),
 		EnvironmentID:     apikeyauth.EnvID(ctx),
-		AccessCode:        &samlAccessCodeUUID,
+		AccessCodeSha256:  samlAccessCodeSHA[:],
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get saml access code data: %w", err)

--- a/migrate/000025_access_token_sha256.up.sql
+++ b/migrate/000025_access_token_sha256.up.sql
@@ -1,0 +1,1 @@
+alter table saml_flows add column access_code_sha256 bytea unique;

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 15.3 (Debian 15.3-1.pgdg120+1)
--- Dumped by pg_dump version 16.0
+-- Dumped by pg_dump version 16.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -28,6 +28,30 @@ CREATE TYPE public.saml_flow_status AS ENUM (
 
 
 ALTER TYPE public.saml_flow_status OWNER TO postgres;
+
+--
+-- Name: river_job_notify(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.river_job_notify() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  payload json;
+BEGIN
+  IF NEW.state = 'available' THEN
+    -- Notify will coalesce duplicate notificiations within a transaction, so
+    -- keep these payloads generalized:
+    payload = json_build_object('queue', NEW.queue);
+    PERFORM
+      pg_notify('river_insert', payload::text);
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.river_job_notify() OWNER TO postgres;
 
 SET default_tablespace = '';
 
@@ -203,7 +227,8 @@ CREATE TABLE public.saml_flows (
     error_bad_subject_id character varying,
     error_email_outside_organization_domains character varying,
     status public.saml_flow_status NOT NULL,
-    error_unsigned_assertion boolean DEFAULT false NOT NULL
+    error_unsigned_assertion boolean DEFAULT false NOT NULL,
+    access_code_sha256 bytea
 );
 
 
@@ -347,6 +372,14 @@ ALTER TABLE ONLY public.saml_connections
 
 ALTER TABLE ONLY public.saml_flows
     ADD CONSTRAINT saml_flows_access_code_key UNIQUE (access_code);
+
+
+--
+-- Name: saml_flows saml_flows_access_code_sha256_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.saml_flows
+    ADD CONSTRAINT saml_flows_access_code_sha256_key UNIQUE (access_code_sha256);
 
 
 --

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -29,30 +29,6 @@ CREATE TYPE public.saml_flow_status AS ENUM (
 
 ALTER TYPE public.saml_flow_status OWNER TO postgres;
 
---
--- Name: river_job_notify(); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.river_job_notify() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-  payload json;
-BEGIN
-  IF NEW.state = 'available' THEN
-    -- Notify will coalesce duplicate notificiations within a transaction, so
-    -- keep these payloads generalized:
-    payload = json_build_object('queue', NEW.queue);
-    PERFORM
-      pg_notify('river_insert', payload::text);
-  END IF;
-  RETURN NULL;
-END;
-$$;
-
-
-ALTER FUNCTION public.river_job_notify() OWNER TO postgres;
-
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;


### PR DESCRIPTION
To bring SAML access tokens in line with the security posture typically used by OAuth2 tokens, this PR makes SAML access tokens expire (by wiping them out from the database entirely) on redemption. This PR also makes us store only the SHA256 of SAML access tokens, not their plaintext inputs.

This change also requires some updates to the onboarding page. Some changes to the state management in that page helps us avoid double-redeeming SAML access tokens. It also adds a new UI path to handle the user electing to redeem the token themselves out of band.

While I was touching onboarding, I elected to also change the code snippets to use camel case, in alignment with our docs.