### PR TITLE
Update email configuration for dev-ucarion and stage

### DIFF
--- a/cmd/api/task-definition-dev-ucarion.json
+++ b/cmd/api/task-definition-dev-ucarion.json
@@ -27,6 +27,14 @@
         {
           "name": "API_GLOBAL_DEFAULT_AUTH_URL",
           "value": "https://auth.dev-ucarion.ssoready-nonprod.com"
+        },
+        {
+          "name": "API_EMAIL_CHALLENGE_FROM",
+          "value": "noreply-dev-ucarion@mail.ssoready.com"
+        },
+        {
+          "name": "API_EMAIL_VERIFICATION_ENDPOINT",
+          "value": "https://app.dev-ucarion.ssoready-nonprod.com/verify-email"
         }
       ],
       "environmentFiles": [],

--- a/cmd/api/task-definition-stage.json
+++ b/cmd/api/task-definition-stage.json
@@ -27,6 +27,14 @@
         {
           "name": "API_GLOBAL_DEFAULT_AUTH_URL",
           "value": "https://auth.stage.ssoready-nonprod.com"
+        },
+        {
+          "name": "API_EMAIL_CHALLENGE_FROM",
+          "value": "noreply-stage@mail.ssoready.com"
+        },
+        {
+          "name": "API_EMAIL_VERIFICATION_ENDPOINT",
+          "value": "https://app.stage.ssoready-nonprod.com/verify-email"
         }
       ],
       "environmentFiles": [],


### PR DESCRIPTION
This PR makes logging in with email work for folks other than myself in dev-ucarion and stage. Turns out the default email address only works for the creator of a Resend account.