### PR TITLE
app: Add Sentry

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -1,3 +1,5 @@
+APP_SENTRY_DSN=https://09e173929eea645e67bf9f24be232ee0@o4505847296557056.ingest.us.sentry.io/4507330647621632
+APP_SENTRY_ENVIRONMENT=local
 APP_API_URL=http://localhost:8081/internal/connect
 APP_APP_URL=http://localhost:8082
 APP_PUBLIC_API_URL=http://localhost:8081

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -25,6 +25,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-tabs": "^1.0.4",
         "@react-oauth/google": "^0.12.1",
+        "@sentry/react": "^8.7.0",
         "@tailwindcss/forms": "^0.5.7",
         "@tanstack/react-query": "^5.32.0",
         "@types/node": "^20.12.7",
@@ -1238,6 +1239,126 @@
       "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.7.0.tgz",
+      "integrity": "sha512-RFBK1sYBwV5qGMEwWF0rjOTqQpp4/SvE+qHkOJNRUTVYmfjM+Y9lcxwn4B6lu3aboxePpBw/i1PlP6XwX4UnGA==",
+      "dependencies": {
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.7.0.tgz",
+      "integrity": "sha512-qcGtWCtRB4eP7NVQoxW936oPkU4qu9otMLYELPGmOJPnuAG0lujlJXW7BucaM7ADyJgJTE75hG849bHecfnbmQ==",
+      "dependencies": {
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.7.0.tgz",
+      "integrity": "sha512-bQzOkWplaWTe3u+aDBhxWY3Qy0aT7ss2A3VR8iC6N8ZIEP9PxqyJwTNoouhinfgmlnCguI7RDOO4f3r3e2M80Q==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.7.0.tgz",
+      "integrity": "sha512-FOnvBPbq6MJVHPduc0hcsdE3PeeovQ2z5WJnZDGhvp/Obehxqe+XgX7K/595vRIknv4EokRn/3Kw0mFwG8E+ZQ==",
+      "dependencies": {
+        "@sentry-internal/replay": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.7.0.tgz",
+      "integrity": "sha512-4EEp+PlcktsMN0p+MdCPl/lghTkq7eOtZjQG9NGhWzfyWrJ3tuL1nsDr2SSivJ1V277F01KtKYo6BFwP2NtBZA==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.7.0",
+        "@sentry-internal/feedback": "8.7.0",
+        "@sentry-internal/replay": "8.7.0",
+        "@sentry-internal/replay-canvas": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.7.0.tgz",
+      "integrity": "sha512-Sq/46B+5nWmgnCD6dEMZ6HTkKbV/KAdgaSvT8oXDb9OWoPy1jJ/gbLrhLs62KbjuDQk4/vWnOgHiKQbcslSzMw==",
+      "dependencies": {
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.7.0.tgz",
+      "integrity": "sha512-JFo8QW8JB4eaFC8RdkOBO96JvlGgstywmyMZ39qWfFbD735vGl8PnOa0AnrC/5Auc86dZ98/I4OEPboqUE9q1w==",
+      "dependencies": {
+        "@sentry/browser": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-11KLOKumP6akugVGLvSoEig+JlP0ZEzW3nN9P+ppgdIx9HAxMIh6UvumbieG4/DWjAh2kh6NPNfUw3gk2Gfq1A==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-aWmcbSoOmrbzll/FkNQFJcCtLAuJLvTYbRKiCSkV3FScA7UaA742HkTZAPFiioALFIESWk/fcGZqtN0s4I281Q==",
+      "dependencies": {
+        "@sentry/types": "8.7.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@tailwindcss/forms": {
@@ -3492,6 +3613,14 @@
       "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -6978,6 +7107,96 @@
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
       "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q=="
     },
+    "@sentry-internal/browser-utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.7.0.tgz",
+      "integrity": "sha512-RFBK1sYBwV5qGMEwWF0rjOTqQpp4/SvE+qHkOJNRUTVYmfjM+Y9lcxwn4B6lu3aboxePpBw/i1PlP6XwX4UnGA==",
+      "requires": {
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      }
+    },
+    "@sentry-internal/feedback": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.7.0.tgz",
+      "integrity": "sha512-qcGtWCtRB4eP7NVQoxW936oPkU4qu9otMLYELPGmOJPnuAG0lujlJXW7BucaM7ADyJgJTE75hG849bHecfnbmQ==",
+      "requires": {
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      }
+    },
+    "@sentry-internal/replay": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.7.0.tgz",
+      "integrity": "sha512-bQzOkWplaWTe3u+aDBhxWY3Qy0aT7ss2A3VR8iC6N8ZIEP9PxqyJwTNoouhinfgmlnCguI7RDOO4f3r3e2M80Q==",
+      "requires": {
+        "@sentry-internal/browser-utils": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.7.0.tgz",
+      "integrity": "sha512-FOnvBPbq6MJVHPduc0hcsdE3PeeovQ2z5WJnZDGhvp/Obehxqe+XgX7K/595vRIknv4EokRn/3Kw0mFwG8E+ZQ==",
+      "requires": {
+        "@sentry-internal/replay": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      }
+    },
+    "@sentry/browser": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.7.0.tgz",
+      "integrity": "sha512-4EEp+PlcktsMN0p+MdCPl/lghTkq7eOtZjQG9NGhWzfyWrJ3tuL1nsDr2SSivJ1V277F01KtKYo6BFwP2NtBZA==",
+      "requires": {
+        "@sentry-internal/browser-utils": "8.7.0",
+        "@sentry-internal/feedback": "8.7.0",
+        "@sentry-internal/replay": "8.7.0",
+        "@sentry-internal/replay-canvas": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      }
+    },
+    "@sentry/core": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.7.0.tgz",
+      "integrity": "sha512-Sq/46B+5nWmgnCD6dEMZ6HTkKbV/KAdgaSvT8oXDb9OWoPy1jJ/gbLrhLs62KbjuDQk4/vWnOgHiKQbcslSzMw==",
+      "requires": {
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0"
+      }
+    },
+    "@sentry/react": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.7.0.tgz",
+      "integrity": "sha512-JFo8QW8JB4eaFC8RdkOBO96JvlGgstywmyMZ39qWfFbD735vGl8PnOa0AnrC/5Auc86dZ98/I4OEPboqUE9q1w==",
+      "requires": {
+        "@sentry/browser": "8.7.0",
+        "@sentry/core": "8.7.0",
+        "@sentry/types": "8.7.0",
+        "@sentry/utils": "8.7.0",
+        "hoist-non-react-statics": "^3.3.2"
+      }
+    },
+    "@sentry/types": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-11KLOKumP6akugVGLvSoEig+JlP0ZEzW3nN9P+ppgdIx9HAxMIh6UvumbieG4/DWjAh2kh6NPNfUw3gk2Gfq1A=="
+    },
+    "@sentry/utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-aWmcbSoOmrbzll/FkNQFJcCtLAuJLvTYbRKiCSkV3FScA7UaA742HkTZAPFiioALFIESWk/fcGZqtN0s4I281Q==",
+      "requires": {
+        "@sentry/types": "8.7.0"
+      }
+    },
     "@tailwindcss/forms": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
@@ -8562,6 +8781,14 @@
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
       "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "hosted-git-info": {
       "version": "2.8.9",

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@react-oauth/google": "^0.12.1",
+    "@sentry/react": "^8.7.0",
     "@tailwindcss/forms": "^0.5.7",
     "@tanstack/react-query": "^5.32.0",
     "@types/node": "^20.12.7",

--- a/app/src/components/LoginGate.tsx
+++ b/app/src/components/LoginGate.tsx
@@ -3,6 +3,7 @@ import { whoami } from "../gen/ssoready/v1/ssoready-SSOReadyService_connectquery
 import { ReactNode, useEffect } from "react";
 import { Outlet, useNavigate } from "react-router";
 import React from "react";
+import * as Sentry from "@sentry/react";
 
 export function LoginGate() {
   const { data, error } = useQuery(
@@ -18,7 +19,15 @@ export function LoginGate() {
     if (error) {
       navigate("/login");
     }
-  }, [error, navigate]);
+
+    if (data) {
+      Sentry.setUser({
+        id: data.appUserId,
+        email: data.email,
+        username: data.displayName,
+      });
+    }
+  }, [data, error, navigate]);
 
   return data ? <Outlet /> : <></>;
 }

--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -1,3 +1,5 @@
+export const SENTRY_DSN = process.env.APP_SENTRY_DSN!;
+export const SENTRY_ENVIRONMENT = process.env.APP_SENTRY_ENVIRONMENT!;
 export const API_URL = process.env.APP_API_URL!;
 export const APP_URL = process.env.APP_APP_URL;
 export const PUBLIC_API_URL = process.env.APP_PUBLIC_API_URL!;

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -6,6 +6,22 @@ import bash from "highlight.js/lib/languages/bash";
 import xml from "highlight.js/lib/languages/xml";
 import json from "highlight.js/lib/languages/json";
 
+import * as Sentry from "@sentry/react";
+import { SENTRY_DSN, SENTRY_ENVIRONMENT } from "@/config";
+
+Sentry.init({
+  dsn: SENTRY_DSN,
+  environment: SENTRY_ENVIRONMENT,
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
+    Sentry.httpClientIntegration(),
+  ],
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 1.0,
+  debug: true,
+});
+
 hljs.registerLanguage("bash", bash);
 hljs.registerLanguage("xml", xml);
 hljs.registerLanguage("json", json);


### PR DESCRIPTION
This PR adds Sentry configuration for the app. We'll do the backend separately.

Two new env vars are needed now: `APP_SENTRY_DSN` and `APP_SENTRY_ENVIRONMENT`. They just get piped into Sentry; better to avoid doing nontrivial things with this baseline layer of observability in our stack.

I set up LoginGate to forward along details about the user when they hit errors, and enabled automatic logging of all failed browser requests.