### PR TITLE
Store only sha256 of session tokens

### DIFF
--- a/internal/apiservice/signin.go
+++ b/internal/apiservice/signin.go
@@ -95,7 +95,7 @@ func (s *Service) SignIn(ctx context.Context, req *connect.Request[ssoreadyv1.Si
 		Token: req.Msg.EmailVerifyToken,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("store: %w", err)
+		return nil, fmt.Errorf("store: verify email: %w", err)
 	}
 
 	sessionRes, err := s.Store.GetAppSession(ctx, &store.GetAppSessionRequest{
@@ -103,7 +103,7 @@ func (s *Service) SignIn(ctx context.Context, req *connect.Request[ssoreadyv1.Si
 		Now:          time.Now(),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("store: %w", err)
+		return nil, fmt.Errorf("store: get app session: %w", err)
 	}
 
 	if err := appanalytics.FromContext(ctx).Enqueue(analytics.Group{

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -67,11 +67,12 @@ type AppOrganization struct {
 }
 
 type AppSession struct {
-	ID         uuid.UUID
-	AppUserID  uuid.UUID
-	CreateTime time.Time
-	ExpireTime time.Time
-	Token      string
+	ID          uuid.UUID
+	AppUserID   uuid.UUID
+	CreateTime  time.Time
+	ExpireTime  time.Time
+	Token       string
+	TokenSha256 []byte
 }
 
 type AppUser struct {
@@ -98,10 +99,10 @@ type Environment struct {
 
 type OnboardingState struct {
 	AppOrganizationID          uuid.UUID
+	DummyidpAppID              string
 	OnboardingEnvironmentID    uuid.UUID
 	OnboardingOrganizationID   uuid.UUID
 	OnboardingSamlConnectionID uuid.UUID
-	DummyidpAppID              string
 }
 
 type Organization struct {

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -3,8 +3,10 @@ package store
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,9 +26,15 @@ type GetAppSessionResponse struct {
 }
 
 func (s *Store) GetAppSession(ctx context.Context, req *GetAppSessionRequest) (*GetAppSessionResponse, error) {
-	appSession, err := s.q.GetAppSessionByToken(ctx, queries.GetAppSessionByTokenParams{
-		Token:      req.SessionToken,
-		ExpireTime: req.Now,
+	token, err := hex.DecodeString(req.SessionToken)
+	if err != nil {
+		return nil, fmt.Errorf("parse session token: %w", err)
+	}
+
+	sha := sha256.Sum256(token)
+	appSession, err := s.q.GetAppSessionByTokenSHA256(ctx, queries.GetAppSessionByTokenSHA256Params{
+		TokenSha256: sha[:],
+		ExpireTime:  req.Now,
 	})
 	if err != nil {
 		return nil, err
@@ -60,21 +68,21 @@ func (s *Store) CreateGoogleSession(ctx context.Context, req *CreateGoogleSessio
 		return nil, err
 	}
 
-	// generate token as 32-byte random string, hex-encoded
+	// generate token as 32-byte random string
 	var tokenBytes [32]byte
 	if _, err := rand.Read(tokenBytes[:]); err != nil {
 		return nil, err
 	}
-	token := hex.EncodeToString(tokenBytes[:])
+	tokenHex := hex.EncodeToString(tokenBytes[:])
+	tokenSHA := sha256.Sum256(tokenBytes[:])
 
-	appSession, err := q.CreateAppSession(ctx, queries.CreateAppSessionParams{
-		ID:         uuid.New(),
-		AppUserID:  appUser.ID,
-		CreateTime: time.Now(),
-		ExpireTime: time.Now().Add(time.Hour * 24 * 7),
-		Token:      token,
-	})
-	if err != nil {
+	if _, err := q.CreateAppSession(ctx, queries.CreateAppSessionParams{
+		ID:          uuid.New(),
+		AppUserID:   appUser.ID,
+		CreateTime:  time.Now(),
+		ExpireTime:  time.Now().Add(time.Hour * 24 * 7),
+		TokenSha256: tokenSHA[:],
+	}); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +90,7 @@ func (s *Store) CreateGoogleSession(ctx context.Context, req *CreateGoogleSessio
 		return nil, err
 	}
 
-	return &CreateGoogleSessionResponse{SessionToken: appSession.Token}, nil
+	return &CreateGoogleSessionResponse{SessionToken: tokenHex}, nil
 }
 
 func (s *Store) upsertGoogleAppUser(ctx context.Context, q *queries.Queries, req *CreateGoogleSessionRequest) (*queries.AppUser, error) {
@@ -203,19 +211,19 @@ func (s *Store) VerifyEmail(ctx context.Context, req *VerifyEmailRequest) (*Veri
 		return nil, err
 	}
 
-	// generate token as 32-byte random string, hex-encoded
+	// generate token as 32-byte random string
 	var tokenBytes [32]byte
 	if _, err := rand.Read(tokenBytes[:]); err != nil {
 		return nil, err
 	}
-	token := hex.EncodeToString(tokenBytes[:])
+	tokenSHA := sha256.Sum256(tokenBytes[:])
 
 	appSession, err := q.CreateAppSession(ctx, queries.CreateAppSessionParams{
-		ID:         uuid.New(),
-		AppUserID:  appUser.ID,
-		CreateTime: time.Now(),
-		ExpireTime: time.Now().Add(time.Hour * 24 * 7),
-		Token:      token,
+		ID:          uuid.New(),
+		AppUserID:   appUser.ID,
+		CreateTime:  time.Now(),
+		ExpireTime:  time.Now().Add(time.Hour * 24 * 7),
+		TokenSha256: tokenSHA[:],
 	})
 	if err != nil {
 		return nil, err

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -216,16 +216,16 @@ func (s *Store) VerifyEmail(ctx context.Context, req *VerifyEmailRequest) (*Veri
 	if _, err := rand.Read(tokenBytes[:]); err != nil {
 		return nil, err
 	}
+	tokenHex := hex.EncodeToString(tokenBytes[:])
 	tokenSHA := sha256.Sum256(tokenBytes[:])
 
-	appSession, err := q.CreateAppSession(ctx, queries.CreateAppSessionParams{
+	if _, err := q.CreateAppSession(ctx, queries.CreateAppSessionParams{
 		ID:          uuid.New(),
 		AppUserID:   appUser.ID,
 		CreateTime:  time.Now(),
 		ExpireTime:  time.Now().Add(time.Hour * 24 * 7),
 		TokenSha256: tokenSHA[:],
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
 
@@ -233,7 +233,7 @@ func (s *Store) VerifyEmail(ctx context.Context, req *VerifyEmailRequest) (*Veri
 		return nil, err
 	}
 
-	return &VerifyEmailResponse{SessionToken: appSession.Token}, nil
+	return &VerifyEmailResponse{SessionToken: tokenHex}, nil
 }
 
 func (s *Store) upsertUserByEmailSoleInOrg(ctx context.Context, q *queries.Queries, email string) (*queries.AppUser, error) {

--- a/migrate/000026_session_token_sha256.up.sql
+++ b/migrate/000026_session_token_sha256.up.sql
@@ -1,0 +1,2 @@
+alter table app_sessions add column token_sha256 bytea unique;
+alter table app_sessions drop constraint app_sessions_token_key;

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -194,15 +194,15 @@ values ($1, $2, $3, $4)
 returning *;
 
 -- name: CreateAppSession :one
-insert into app_sessions (id, app_user_id, create_time, expire_time, token)
-values ($1, $2, $3, $4, $5)
+insert into app_sessions (id, app_user_id, create_time, expire_time, token, token_sha256)
+values ($1, $2, $3, $4, '', $5)
 returning *;
 
--- name: GetAppSessionByToken :one
+-- name: GetAppSessionByTokenSHA256 :one
 select app_sessions.app_user_id, app_users.app_organization_id
 from app_sessions
          join app_users on app_sessions.app_user_id = app_users.id
-where token = $1
+where token_sha256 = $1
   and expire_time > $2;
 
 -- name: ListEnvironments :many

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -67,7 +67,8 @@ CREATE TABLE public.app_sessions (
     app_user_id uuid NOT NULL,
     create_time timestamp with time zone NOT NULL,
     expire_time timestamp with time zone NOT NULL,
-    token character varying NOT NULL
+    token character varying NOT NULL,
+    token_sha256 bytea
 );
 
 
@@ -122,10 +123,10 @@ ALTER TABLE public.environments OWNER TO postgres;
 
 CREATE TABLE public.onboarding_states (
     app_organization_id uuid NOT NULL,
+    dummyidp_app_id character varying NOT NULL,
     onboarding_environment_id uuid NOT NULL,
     onboarding_organization_id uuid NOT NULL,
-    onboarding_saml_connection_id uuid NOT NULL,
-    dummyidp_app_id character varying NOT NULL
+    onboarding_saml_connection_id uuid NOT NULL
 );
 
 
@@ -268,6 +269,14 @@ ALTER TABLE ONLY public.app_sessions
 
 ALTER TABLE ONLY public.app_sessions
     ADD CONSTRAINT app_sessions_token_key UNIQUE (token);
+
+
+--
+-- Name: app_sessions app_sessions_token_sha256_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.app_sessions
+    ADD CONSTRAINT app_sessions_token_sha256_key UNIQUE (token_sha256);
 
 
 --


### PR DESCRIPTION
This PR has us store only the SHA256 of session tokens. The original value of a session is unchanged in this PR (it's still 32 bytes of randomness), but now lookups all first sha256 the input and check for a match that way.