### PR TITLE
Store only SHA256 of API key tokens

### DIFF
--- a/internal/store/onboarding.go
+++ b/internal/store/onboarding.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 
@@ -62,7 +63,14 @@ func (s *Store) UpdateOnboardingState(ctx context.Context, req *ssoreadyv1.Updat
 }
 
 func (s *Store) OnboardingGetSAMLRedirectURL(ctx context.Context, req *ssoreadyv1.OnboardingGetSAMLRedirectURLRequest) (*ssoreadyv1.GetSAMLRedirectURLResponse, error) {
-	apiKey, err := s.q.GetAPIKeyBySecretValue(ctx, req.ApiKeySecretToken)
+	secretValue, err := idformat.APISecretKey.Parse(req.ApiKeySecretToken)
+	if err != nil {
+		return nil, fmt.Errorf("parse api secret key: %w", err)
+	}
+
+	secretValueSHA := sha256.Sum256(secretValue[:])
+
+	apiKey, err := s.q.GetAPIKeyBySecretValueSHA256(ctx, secretValueSHA[:])
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +90,14 @@ func (s *Store) OnboardingGetSAMLRedirectURL(ctx context.Context, req *ssoreadyv
 }
 
 func (s *Store) OnboardingRedeemSAMLAccessCode(ctx context.Context, req *ssoreadyv1.OnboardingRedeemSAMLAccessCodeRequest) (*ssoreadyv1.RedeemSAMLAccessCodeResponse, error) {
-	apiKey, err := s.q.GetAPIKeyBySecretValue(ctx, req.ApiKeySecretToken)
+	secretValue, err := idformat.APISecretKey.Parse(req.ApiKeySecretToken)
+	if err != nil {
+		return nil, fmt.Errorf("parse api secret key: %w", err)
+	}
+
+	secretValueSHA := sha256.Sum256(secretValue[:])
+
+	apiKey, err := s.q.GetAPIKeyBySecretValueSHA256(ctx, secretValueSHA[:])
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -56,9 +56,10 @@ func (ns NullSamlFlowStatus) Value() (driver.Value, error) {
 }
 
 type ApiKey struct {
-	ID            uuid.UUID
-	SecretValue   string
-	EnvironmentID uuid.UUID
+	ID                uuid.UUID
+	SecretValue       string
+	EnvironmentID     uuid.UUID
+	SecretValueSha256 []byte
 }
 
 type AppOrganization struct {

--- a/migrate/000027_api_key_secret_value_sha256.up.sql
+++ b/migrate/000027_api_key_secret_value_sha256.up.sql
@@ -1,0 +1,1 @@
+alter table api_keys add column secret_value_sha256 bytea unique;

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -145,11 +145,11 @@ select *
 from environments
 where id = $1;
 
--- name: GetAPIKeyBySecretValue :one
+-- name: GetAPIKeyBySecretValueSHA256 :one
 select api_keys.*, environments.app_organization_id
 from api_keys
          join environments on api_keys.environment_id = environments.id
-where secret_value = $1;
+where secret_value_sha256 = $1;
 
 -- name: GetSAMLAccessCodeData :one
 select saml_flows.id             as saml_flow_id,
@@ -248,8 +248,8 @@ where environments.app_organization_id = $1
   and api_keys.id = $2;
 
 -- name: CreateAPIKey :one
-insert into api_keys (id, secret_value, environment_id)
-values ($1, $2, $3)
+insert into api_keys (id, secret_value, secret_value_sha256, environment_id)
+values ($1, '', $2, $3)
 returning *;
 
 -- name: DeleteAPIKey :exec

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -40,7 +40,8 @@ SET default_table_access_method = heap;
 CREATE TABLE public.api_keys (
     id uuid NOT NULL,
     secret_value character varying NOT NULL,
-    environment_id uuid NOT NULL
+    environment_id uuid NOT NULL,
+    secret_value_sha256 bytea
 );
 
 
@@ -232,6 +233,14 @@ ALTER TABLE ONLY public.api_keys
 
 
 --
+-- Name: api_keys api_keys_secret_value_sha256_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_keys
+    ADD CONSTRAINT api_keys_secret_value_sha256_key UNIQUE (secret_value_sha256);
+
+
+--
 -- Name: app_organizations app_organizations_google_hosted_domain_key; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -261,14 +270,6 @@ ALTER TABLE ONLY public.app_organizations
 
 ALTER TABLE ONLY public.app_sessions
     ADD CONSTRAINT app_sessions_pkey PRIMARY KEY (id);
-
-
---
--- Name: app_sessions app_sessions_token_key; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.app_sessions
-    ADD CONSTRAINT app_sessions_token_key UNIQUE (token);
 
 
 --


### PR DESCRIPTION
This PR is akin to #19, but for API keys. API Keys remain a `ssoready_sk_`-prefixed UUID when presented from the API, but only the SHA256 of the underlying UUID is stored. This PR moves API lookups to convert the input to its SHA256 for an equality match.