### PR TITLE
Make sidebar state clearer when no environment selected

### DIFF
--- a/app/src/components/EnvironmentSwitcher.tsx
+++ b/app/src/components/EnvironmentSwitcher.tsx
@@ -38,7 +38,15 @@ export function EnvironmentSwitcher() {
         >
           <span className="flex items-center gap-2">
             <Box className="h-4 w-4" />
-            <span className="font-medium">{currentEnv?.displayName}</span>
+            <span className="font-medium">
+              {currentEnv ? (
+                currentEnv.displayName
+              ) : (
+                <span className="font-normal text-gray-500">
+                  No environment selected
+                </span>
+              )}
+            </span>
           </span>
           <ChevronDown className="h-4 w-4" />
         </Button>

--- a/app/src/components/Page.tsx
+++ b/app/src/components/Page.tsx
@@ -18,13 +18,15 @@ export function Page() {
           <EnvironmentSwitcher />
 
           <div className="m-2">
-            <Link
-              to={`/environments/${environmentId}`}
-              className="flex gap-2 items-center p-2 hover:bg-gray-100 rounded-sm text-sm"
-            >
-              <LayoutGrid className="h-4 w-4" />
-              <span>Overview</span>
-            </Link>
+            {environmentId && (
+              <Link
+                to={`/environments/${environmentId}`}
+                className="flex gap-2 items-center p-2 hover:bg-gray-100 rounded-sm text-sm"
+              >
+                <LayoutGrid className="h-4 w-4" />
+                <span>Overview</span>
+              </Link>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Hide the "Overview" link when no environment is selected, and add an empty display treatment in the environment switcher dropdown in that case as well.

![Screenshot 2024-06-03 at 1 08 09 PM](https://github.com/ssoready/ssoready/assets/2180153/a709079c-cd3a-41b8-a8a7-9e8fbfb524eb)
