### PR TITLE
app: index: disable sentry non-error samples

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -17,7 +17,7 @@ Sentry.init({
     Sentry.replayIntegration(),
     Sentry.httpClientIntegration(),
   ],
-  replaysSessionSampleRate: 1.0,
+  replaysSessionSampleRate: 0.0,
   replaysOnErrorSampleRate: 1.0,
   debug: true,
 });


### PR DESCRIPTION
This PR disables replay session samples for Sentry outside of errors.