### PR TITLE
app: send empty string when no session token is present

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,7 +28,7 @@ const transport = createConnectTransport({
   baseUrl: API_URL,
   interceptors: [
     (next) => async (req) => {
-      req.header.set("Authorization", `Bearer ${getSessionToken()}`);
+      req.header.set("Authorization", `Bearer ${getSessionToken() ?? ""}`);
       return next(req);
     },
   ],


### PR DESCRIPTION
This makes the backend return a simpler 401 instead of having to detect that "null" is not, in fact, a valid session token. That in turn makes the Sentry error logs less noisy.