### PR TITLE
Add identify call on signup

### DIFF
--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -540,7 +540,7 @@ func (q *Queries) GetAppOrganizationByGoogleHostedDomain(ctx context.Context, go
 }
 
 const getAppSessionByTokenSHA256 = `-- name: GetAppSessionByTokenSHA256 :one
-select app_sessions.app_user_id, app_users.app_organization_id
+select app_sessions.app_user_id, app_users.display_name, app_users.email, app_users.app_organization_id
 from app_sessions
          join app_users on app_sessions.app_user_id = app_users.id
 where token_sha256 = $1
@@ -554,13 +554,20 @@ type GetAppSessionByTokenSHA256Params struct {
 
 type GetAppSessionByTokenSHA256Row struct {
 	AppUserID         uuid.UUID
+	DisplayName       string
+	Email             string
 	AppOrganizationID uuid.UUID
 }
 
 func (q *Queries) GetAppSessionByTokenSHA256(ctx context.Context, arg GetAppSessionByTokenSHA256Params) (GetAppSessionByTokenSHA256Row, error) {
 	row := q.db.QueryRow(ctx, getAppSessionByTokenSHA256, arg.TokenSha256, arg.ExpireTime)
 	var i GetAppSessionByTokenSHA256Row
-	err := row.Scan(&i.AppUserID, &i.AppOrganizationID)
+	err := row.Scan(
+		&i.AppUserID,
+		&i.DisplayName,
+		&i.Email,
+		&i.AppOrganizationID,
+	)
 	return i, err
 }
 

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -21,8 +21,10 @@ type GetAppSessionRequest struct {
 }
 
 type GetAppSessionResponse struct {
-	AppUserID         string
-	AppOrganizationID uuid.UUID
+	AppUserID          string
+	AppOrganizationID  uuid.UUID
+	AppUserDisplayName string
+	AppUserEmail       string
 }
 
 func (s *Store) GetAppSession(ctx context.Context, req *GetAppSessionRequest) (*GetAppSessionResponse, error) {
@@ -41,8 +43,10 @@ func (s *Store) GetAppSession(ctx context.Context, req *GetAppSessionRequest) (*
 	}
 
 	return &GetAppSessionResponse{
-		AppUserID:         idformat.AppUser.Format(appSession.AppUserID),
-		AppOrganizationID: appSession.AppOrganizationID,
+		AppUserID:          idformat.AppUser.Format(appSession.AppUserID),
+		AppOrganizationID:  appSession.AppOrganizationID,
+		AppUserDisplayName: appSession.DisplayName,
+		AppUserEmail:       appSession.Email,
 	}, nil
 }
 

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -199,7 +199,7 @@ values ($1, $2, $3, $4, '', $5)
 returning *;
 
 -- name: GetAppSessionByTokenSHA256 :one
-select app_sessions.app_user_id, app_users.app_organization_id
+select app_sessions.app_user_id, app_users.display_name, app_users.email, app_users.app_organization_id
 from app_sessions
          join app_users on app_sessions.app_user_id = app_users.id
 where token_sha256 = $1


### PR DESCRIPTION
This PR adds an identify call on user signup. A user's name and email, if known, are associated with the analytics user.

This requires an update to the queries because to this point, retrieving a user session only returned the user ID. It now also returns an email and display name.