### PR TITLE
LoginGate: use replace: true when redirecting

### DIFF
--- a/app/src/components/LoginGate.tsx
+++ b/app/src/components/LoginGate.tsx
@@ -18,7 +18,9 @@ export function LoginGate() {
   const navigate = useNavigate();
   useEffect(() => {
     if (error) {
-      navigate("/login");
+      navigate("/login", {
+        replace: true,
+      });
     }
 
     if (data) {


### PR DESCRIPTION
LoginGate currently "breaks the back button". This PR fixes that. When redirected to `/login` by LoginGate, the back button will go to whatever it was before the user visited a LoginGate-d page.