### PR TITLE
Add permissions block to docker publish-api

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -9,6 +9,9 @@ jobs:
   publish-api:
     name: Publish api
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR is to fix the failure here: https://github.com/ssoready/ssoready/actions/runs/9689363370/job/26737512093