### PR TITLE
docker publish: fix permission issue with id-token

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -5,13 +5,14 @@ on:
       - 'main'
     tags:
       - 'v*'
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 jobs:
   publish-api:
     name: Publish api
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR is to fix: https://github.com/ssoready/ssoready/actions/runs/9689486962/job/26737824308