### PR TITLE
Add auth to publish-docker-images.yaml

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -47,3 +47,40 @@ jobs:
           subject-name: ghcr.io/ssoready/ssoready-api
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  publish-auth:
+    name: Publish auth
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ghcr.io/ssoready/ssoready-auth
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: ./cmd/auth/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/ssoready/ssoready-auth
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This PR adds `auth` to the release process already in place for `api`.