### PR TITLE
oauth: authorize: return 400 when organization not found

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -93,6 +93,12 @@ func (s *Service) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 		SAMLConnectionID:       samlConnID,
 	})
 	if err != nil {
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeInvalidArgument {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		panic(fmt.Errorf("get oauth authorize data: %w", err))
 	}
 

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -322,8 +322,6 @@ func (s *Store) AuthGetOAuthAuthorizeData(ctx context.Context, req *AuthGetOAuth
 			return nil, err
 		}
 
-		fmt.Println("get organization by id", uuid.UUID(envID), uuid.UUID(orgID))
-
 		samlConnID, err = q.GetPrimarySAMLConnectionIDByOrganizationID(ctx, queries.GetPrimarySAMLConnectionIDByOrganizationIDParams{
 			EnvironmentID: envID,
 			ID:            orgID,


### PR DESCRIPTION
This PR has us return a 400 when an OAuth redirect is directed at an organization that doesn't exist.

```console
$ curl http://localhost:8080/v1/oauth/authorize\?client_id=saml_oauth_client_54v5jr37hu34b3nvwmrp0yb3e\&organization_external_id\=123 -v

...

< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Fri, 28 Jun 2024 16:56:15 GMT
< Content-Length: 128
< 
invalid_argument: bad organization_external_id: organization not found, or organization does not have a primary SAML connection
```

This PR also removes a stray logging line.