### PR TITLE
VerifyEmail: fail if there's an existing non-expired challenge for email

### DIFF
--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -200,6 +200,22 @@ func (q *Queries) AuthGetValidateData(ctx context.Context, id uuid.UUID) (AuthGe
 	return i, err
 }
 
+const checkExistsEmailVerificationChallenge = `-- name: CheckExistsEmailVerificationChallenge :one
+select exists(select id, email, expire_time, secret_token from email_verification_challenges where email = $1 and expire_time > $2)
+`
+
+type CheckExistsEmailVerificationChallengeParams struct {
+	Email      string
+	ExpireTime time.Time
+}
+
+func (q *Queries) CheckExistsEmailVerificationChallenge(ctx context.Context, arg CheckExistsEmailVerificationChallengeParams) (bool, error) {
+	row := q.db.QueryRow(ctx, checkExistsEmailVerificationChallenge, arg.Email, arg.ExpireTime)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const createAPIKey = `-- name: CreateAPIKey :one
 insert into api_keys (id, secret_value, secret_value_sha256, environment_id)
 values ($1, '', $2, $3)

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -1,3 +1,6 @@
+-- name: CheckExistsEmailVerificationChallenge :one
+select exists(select * from email_verification_challenges where email = $1 and expire_time > $2);
+
 -- name: CreateEmailVerificationChallenge :one
 insert into email_verification_challenges (id, email, expire_time, secret_token)
 values ($1, $2, $3, $4)


### PR DESCRIPTION
This PR has VerifyEmail fail if there's an outstanding verification challenge for the given email. This is in the spirit of reducing the risk of email bombing.