### PR TITLE
Move publishing of ssoready-auth from ghcr.io to docker.io

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -58,15 +58,14 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ghcr.io/ssoready/ssoready-auth
+          images: ssoready/ssoready-auth
 
       - name: Build and push Docker image
         id: push
@@ -81,7 +80,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghcr.io/ssoready/ssoready-auth
+          subject-name: ssoready/ssoready-auth
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
This PR moves publishing of ssoready-auth from ghcr.io to docker.io, in anticipation of doing the same for all app, api, and migrate as well.