### PR TITLE
publish-docker-images: auth: fix artifact attestation for docker.io

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ssoready/ssoready-auth
+          subject-name: index.docker.io/ssoready/ssoready-auth
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
This PR fixes the attestation for auth to follow the docs here: https://github.com/actions/attest-build-provenance

Namely "NOTE: When pushing to Docker Hub, please use "index.docker.io" as the registry portion of the image name."