### PR TITLE
Use node v22.4 to fix npm regression

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22
+FROM node:22.4
 
 WORKDIR /work
 


### PR DESCRIPTION
The app is failing to build in Docker because of a regression in npm:

https://github.com/npm/cli/issues/7657

This PR fixes that issue by pinning app/Dockerfile to the previous version of npm.