### PR TITLE
app: Add links to docs for lists of envs, orgs, conns, flows

### DIFF
--- a/app/src/components/DocsLink.tsx
+++ b/app/src/components/DocsLink.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { ArrowUpRightIcon } from "lucide-react";
+
+export function DocsLink({ to }: { to: string }) {
+  return (
+    <Link
+      className="ml-4 hover:underline active:text-blue-800 text-xs font-semibold text-blue-600 inline-flex items-center"
+      to={to}
+    >
+      Docs
+      <ArrowUpRightIcon className="ml-0.5 h-3 w-3" />
+    </Link>
+  );
+}

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -30,6 +30,7 @@ import {
   BookOpenTextIcon,
   PlusIcon,
 } from "lucide-react";
+import { DocsLink } from "@/components/DocsLink";
 
 export function HomePage() {
   const { data: onboardingState } = useQuery(getOnboardingState, {});
@@ -98,7 +99,10 @@ export function HomePage() {
         <CardHeader>
           <div className="lg:flex justify-between items-center">
             <div className="flex flex-col space-y-1.5">
-              <CardTitle>Environments</CardTitle>
+              <CardTitle>
+                Environments
+                <DocsLink to="https://ssoready.com/docs/sso-ready-concepts/environments" />
+              </CardTitle>
 
               <CardDescription className="mr-2">
                 An environment corresponds to a deployment environment in your

--- a/app/src/pages/ViewEnvironmentPage.tsx
+++ b/app/src/pages/ViewEnvironmentPage.tsx
@@ -71,6 +71,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewEnvironmentPage() {
   const { environmentId } = useParams();
@@ -140,7 +141,10 @@ export function ViewEnvironmentPage() {
         <CardHeader>
           <div className="flex justify-between items-center">
             <div className="flex flex-col space-y-1.5">
-              <CardTitle>Organizations</CardTitle>
+              <CardTitle>
+                Organizations
+                <DocsLink to="https://ssoready.com/docs/sso-ready-concepts/organizations" />
+              </CardTitle>
 
               <CardDescription>
                 Organizations within this environment.

--- a/app/src/pages/ViewOrganizationPage.tsx
+++ b/app/src/pages/ViewOrganizationPage.tsx
@@ -77,6 +77,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewOrganizationPage() {
   const { environmentId, organizationId } = useParams();
@@ -180,7 +181,10 @@ export function ViewOrganizationPage() {
         <CardHeader>
           <div className="flex justify-between items-center">
             <div className="flex flex-col space-y-1.5">
-              <CardTitle>SAML Connections</CardTitle>
+              <CardTitle>
+                SAML Connections
+                <DocsLink to="https://ssoready.com/docs/sso-ready-concepts/saml-connections" />
+              </CardTitle>
               <CardDescription>
                 SAML Connections within this organization.
               </CardDescription>

--- a/app/src/pages/ViewSAMLConnectionPage.tsx
+++ b/app/src/pages/ViewSAMLConnectionPage.tsx
@@ -79,6 +79,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { InputTags } from "@/components/InputTags";
 import { Switch } from "@/components/ui/switch";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewSAMLConnectionPage() {
   const { environmentId, organizationId, samlConnectionId } = useParams();
@@ -361,7 +362,10 @@ function ListLoginFlowsTabContent() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>SAML Login Flows</CardTitle>
+        <CardTitle>
+          SAML Login Flows
+          <DocsLink to="https://ssoready.com/docs/sso-ready-concepts/login-flows" />
+        </CardTitle>
         <CardDescription>
           SAML login flows from this connection are listed here.
         </CardDescription>


### PR DESCRIPTION
This PR adds links to ssoready.com/docs to the headers of tables listing environments, organizations, saml connections, and saml flows.

<img width="1552" alt="Screenshot 2024-07-24 at 2 25 52 PM" src="https://github.com/user-attachments/assets/e6b710c4-ed2e-49bc-ab30-a13c63cde369">

<img width="1552" alt="Screenshot 2024-07-24 at 2 25 58 PM" src="https://github.com/user-attachments/assets/a890da7a-1ffb-4d85-aaff-070d1da55579">

<img width="1552" alt="Screenshot 2024-07-24 at 2 26 05 PM" src="https://github.com/user-attachments/assets/9293b3fa-7b13-4bd3-a48f-dca13327bafb">
<img width="1552" alt="Screenshot 2024-07-24 at 2 26 12 PM" src="https://github.com/user-attachments/assets/4dce2d68-956b-4f0a-8223-724b48539bcf">
