### PR TITLE
api, auth, migrate: update Dockerfile to use BUILDPLATFORM, TARGETOS, TARGETARCH

### DIFF
--- a/cmd/api/Dockerfile
+++ b/cmd/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 
 RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates
 
@@ -10,7 +10,9 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-w -s" -o api ./cmd/api
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags "-w -s" -o api ./cmd/api
 
 FROM scratch
 

--- a/cmd/auth/Dockerfile
+++ b/cmd/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 
 RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates
 
@@ -10,7 +10,9 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -o auth ./cmd/auth
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags "-w -s" -o auth ./cmd/auth
 
 FROM scratch
 

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 
 RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates
 
@@ -10,7 +10,9 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -o migrate ./cmd/migrate
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags "-w -s" -o migrate ./cmd/migrate
 
 FROM scratch
 


### PR DESCRIPTION
In #85 and #86, we started publishing cross-platform Docker images. But those packages still always contained linux/arm64 executables.

This PR follows a process Docker documents here: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/ to enable the Golang builds to produce linux/amd64 artifacts appropriately.