### PR TITLE
deploy-*: use `docker buildx build` to create images

### DIFF
--- a/.github/workflows/deploy-dev-ucarion.yaml
+++ b/.github/workflows/deploy-dev-ucarion.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build, tag, and push Docker image to ECR
         run: |
-          docker build . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
+          docker buildx build --platform linux/arm64 . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
           docker push $ECR_REGISTRY_URL/$SERVICE:$TAG
 
       - name: Create ECS task definition

--- a/.github/workflows/deploy-dev-ucarion.yaml
+++ b/.github/workflows/deploy-dev-ucarion.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build, tag, and push Docker image to ECR
         run: |
-          docker build . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
+          docker buildx build --platform linux/arm64 . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
           docker push $ECR_REGISTRY_URL/$SERVICE:$TAG
 
       - name: Create ECS task definition

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build, tag, and push Docker image to ECR
         run: |
-          docker build . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
+          docker buildx build --platform linux/arm64 . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
           docker push $ECR_REGISTRY_URL/$SERVICE:$TAG
 
       - name: Create ECS task definition
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build, tag, and push Docker image to ECR
         run: |
-          docker build . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
+          docker buildx build --platform linux/arm64 . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
           docker push $ECR_REGISTRY_URL/$SERVICE:$TAG
 
       - name: Create ECS task definition

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build, tag, and push Docker image to ECR
         run: |
-          docker build . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
+          docker buildx build --platform linux/arm64 . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
           docker push $ECR_REGISTRY_URL/$SERVICE:$TAG
 
       - name: Create ECS task definition
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build, tag, and push Docker image to ECR
         run: |
-          docker build . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
+          docker buildx build --platform linux/arm64 . -f ./cmd/$SERVICE/Dockerfile -t $ECR_REGISTRY_URL/$SERVICE:$TAG
           docker push $ECR_REGISTRY_URL/$SERVICE:$TAG
 
       - name: Create ECS task definition


### PR DESCRIPTION
In #87, we updated the Dockerfiles for api and auth to expect to be run from a cross-platform build, defaulting to building for the same platform that the build is happening from.

This PR updates our deploy builds for api and auth to explicitly target linux/arm64.