### PR TITLE
app: ListAPIKeysPage: fix copy for api keys table header

### DIFF
--- a/app/src/pages/ListAPIKeysPage.tsx
+++ b/app/src/pages/ListAPIKeysPage.tsx
@@ -150,7 +150,7 @@ function ListAPIKeysCard() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>SAML OAuth Client ID</TableHead>
+                <TableHead>API Key ID</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>


### PR DESCRIPTION
Closes #74.

<img width="368" alt="Screenshot 2024-08-05 at 2 02 10 PM" src="https://github.com/user-attachments/assets/d566eecf-fe56-4423-b832-813068a2e828">
