### PR TITLE
auth: fix arch in task definitions

### DIFF
--- a/cmd/auth/task-definition-dev-ucarion.json
+++ b/cmd/auth/task-definition-dev-ucarion.json
@@ -100,7 +100,7 @@
   "cpu": "256",
   "memory": "512",
   "runtimePlatform": {
-    "cpuArchitecture": "X86_64",
+    "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
   "registeredAt": "",

--- a/cmd/auth/task-definition-prod.json
+++ b/cmd/auth/task-definition-prod.json
@@ -100,7 +100,7 @@
   "cpu": "256",
   "memory": "512",
   "runtimePlatform": {
-    "cpuArchitecture": "X86_64",
+    "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
   "registeredAt": "",

--- a/cmd/auth/task-definition-stage.json
+++ b/cmd/auth/task-definition-stage.json
@@ -100,7 +100,7 @@
   "cpu": "256",
   "memory": "512",
   "runtimePlatform": {
-    "cpuArchitecture": "X86_64",
+    "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
   "registeredAt": "",


### PR DESCRIPTION
This PR fixes the internal task definitions for auth to use ARM64, not X86_64.