### PR TITLE
app: InputTags: trim input before adding to set

### DIFF
--- a/app/src/components/InputTags.tsx
+++ b/app/src/components/InputTags.tsx
@@ -15,7 +15,8 @@ export const InputTags = forwardRef<HTMLInputElement, InputTagsProps>(
 
     const addPendingDataPoint = () => {
       if (pendingDataPoint) {
-        const newDataPoints = new Set([...value, pendingDataPoint]);
+        // trim() because a copy-pasted input may still contain leading/trailing whitespace
+        const newDataPoints = new Set([...value, pendingDataPoint.trim()]);
         onChange(Array.from(newDataPoints));
         setPendingDataPoint("");
       }


### PR DESCRIPTION
A user discovered that copy-pasting text containing whitespace into the domains list leads to domain whitelist entries containing whitespace. Such entries don't work correctly, and are confusing.

This PR has InputTags trim input values before "adding" them.