### PR TITLE
Improve validation of environment redirect URL formatting

### DIFF
--- a/app/src/pages/CreateEnvironmentPage.tsx
+++ b/app/src/pages/CreateEnvironmentPage.tsx
@@ -38,9 +38,14 @@ const FormSchema = z.object({
   displayName: z.string().min(1, {
     message: "Display name is required.",
   }),
-  redirectUrl: z.string().url({
-    message: "Redirect URL must be a valid URL.",
-  }),
+  redirectUrl: z
+    .string()
+    .url({
+      message: "Redirect URL must be a valid URL.",
+    })
+    .refine((arg) => !arg.includes(" "), {
+      message: "Redirect URL must be a valid URL.",
+    }),
   authUrl: z.string(),
 });
 

--- a/app/src/pages/ViewEnvironmentPage.tsx
+++ b/app/src/pages/ViewEnvironmentPage.tsx
@@ -207,16 +207,26 @@ const FormSchema = z.object({
   displayName: z.string().min(1, {
     message: "Display name is required.",
   }),
-  redirectUrl: z.string().url({
-    message: "Redirect URL must be a valid URL.",
-  }),
+  redirectUrl: z
+    .string()
+    .url({
+      message: "Redirect URL must be a valid URL.",
+    })
+    .refine((arg) => !arg.includes(" "), {
+      message: "Redirect URL must be a valid URL.",
+    }),
   authUrl: z.string(),
   oauthRedirectUri: z
     .string()
     .length(0, {
       message: "OAuth Redirect URI must be empty or a valid URL.",
     })
-    .or(z.string().url()),
+    .or(
+      z
+        .string()
+        .url()
+        .refine((arg) => !arg.includes(" ")),
+    ),
 });
 
 function EditEnvironmentAlertDialog({

--- a/internal/store/environments.go
+++ b/internal/store/environments.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"github.com/google/uuid"
 	"github.com/ssoready/ssoready/internal/authn"
@@ -67,6 +69,11 @@ func (s *Store) CreateEnvironment(ctx context.Context, req *ssoreadyv1.CreateEnv
 	}
 	defer rollback()
 
+	// attempt to parse redirect URL to ensure it's a URL
+	if _, err := url.Parse(req.Environment.RedirectUrl); err != nil {
+		return nil, fmt.Errorf("invalid redirect url: %w", err)
+	}
+
 	var authURL *string
 	if req.Environment.AuthUrl != "" {
 		authURL = &req.Environment.AuthUrl
@@ -94,6 +101,16 @@ func (s *Store) UpdateEnvironment(ctx context.Context, req *ssoreadyv1.UpdateEnv
 	id, err := idformat.Environment.Parse(req.Environment.Id)
 	if err != nil {
 		return nil, err
+	}
+
+	// attempt to parse redirect URL to ensure it's a URL
+	if _, err := url.Parse(req.Environment.RedirectUrl); err != nil {
+		return nil, fmt.Errorf("invalid redirect url: %w", err)
+	}
+
+	// attempt to parse oauth redirect URL to ensure it's a URL
+	if _, err := url.Parse(req.Environment.OauthRedirectUri); err != nil {
+		return nil, fmt.Errorf("invalid redirect url: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)


### PR DESCRIPTION
A customer ran into an issue ultimately caused by putting a leading space in their environment's redirect URL. This PR:

1. Validates that (oauth) redirect URL do not contain spaces
2. Refuses to commit environments whose (oauth) redirect URL does not parse in Go.

There isn't a super easy way to reliably do this URL validate from the frontend; most things in JavaScript-land use WHATWG URLs, but the backend relies on IETF URLs. But this at least improves the user experience for the more common use-case.