### PR TITLE
Ravindr/button resize 77

### DIFF
--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -165,7 +165,7 @@ function MicrosoftLogin() {
   return (
     <Button variant="outline" asChild>
       <a
-        className="flex items-center gap-x-[0.3rem] pl-[0.4rem] pr-[0.4rem]"
+        className="flex items-center gap-x-[0.3rem] pl-[0.4rem] pr-[0.4rem] font-normal"
         href={microsoftRedirectUri.toString()}
       >
         <span>Continue with Microsoft</span>

--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -165,7 +165,7 @@ function MicrosoftLogin() {
   return (
     <Button variant="outline" asChild>
       <a
-        className="flex items-center gap-x-2"
+        className="flex items-center gap-x-[0.3rem] pl-[0.4rem] pr-[0.4rem]"
         href={microsoftRedirectUri.toString()}
       >
         <span>Continue with Microsoft</span>


### PR DESCRIPTION
This PR is related to standardizing the size of OAuth provider buttons across the application to ensure consistency and improve the user experience.

Changes:-
`app/src/pages/LoginPage.tsx` -> Updated padding and gap of login Microsoft button.

Issue: [#77](https://github.com/ssoready/ssoready/issues/77)

<img width="731" alt="Screenshot 2024-08-17 at 00 55 32" src="https://github.com/user-attachments/assets/f538d295-617c-49f9-bf4c-bbf9780f1815">



