### PR TITLE
store: scim_directories: stop populating now-removed ClientBearerToken

### DIFF
--- a/internal/store/scim_directories.go
+++ b/internal/store/scim_directories.go
@@ -236,7 +236,6 @@ func parseSCIMDirectory(qSCIMDirectory queries.ScimDirectory) *ssoreadyv1.SCIMDi
 		OrganizationId:       idformat.Organization.Format(qSCIMDirectory.OrganizationID),
 		Primary:              qSCIMDirectory.IsPrimary,
 		ScimBaseUrl:          qSCIMDirectory.ScimBaseUrl,
-		ClientBearerToken:    "", // intentionally left blank
 		HasClientBearerToken: len(qSCIMDirectory.BearerTokenSha256) > 0,
 	}
 }


### PR DESCRIPTION
This PR fixes a regression introduced in #107. I neglected to include this change in the PR.