### PR TITLE
app: Add SecretCopier, use in api keys, oauth clients, scim bearer tokens

### DIFF
--- a/app/src/components/SecretCopier.tsx
+++ b/app/src/components/SecretCopier.tsx
@@ -1,0 +1,65 @@
+import { Input } from "@/components/ui/input";
+import React, { useCallback, useEffect, useState } from "react";
+import { offset, useFloating, useTransitionStyles } from "@floating-ui/react";
+import { CopyIcon, EyeIcon } from "lucide-react";
+
+export function SecretCopier({
+  placeholder,
+  secret,
+}: {
+  placeholder: string;
+  secret: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    placement: "top",
+    middleware: [offset(5)],
+  });
+  const { isMounted, styles } = useTransitionStyles(context, {
+    duration: 150,
+    initial: { opacity: 0, transform: "translateY(0)" },
+    open: { opacity: 1, transform: "translateY(-5px)" },
+  });
+
+  useEffect(() => {
+    if (open) {
+      const timeoutId = setTimeout(() => {
+        setOpen(false);
+      }, 1000);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [open]);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(secret);
+    setOpen(true);
+  }, [secret, setOpen]);
+
+  return (
+    <div
+      ref={refs.setReference}
+      onClick={handleCopy}
+      className="flex select-none cursor-pointer bg-muted font-mono text-xs border border-input rounded-md px-3 py-2"
+    >
+      <span>{placeholder}</span>
+      <span className="ml-auto flex gap-x-2">
+        <CopyIcon className="cursor-pointer text-muted-foreground hover:text-foreground h-4 w-4" />
+      </span>
+
+      {open && (
+        <div ref={refs.setFloating} style={floatingStyles}>
+          {isMounted && (
+            <div
+              style={styles}
+              className="font-sans bg-black text-white px-2 py-1 text-xs rounded"
+            >
+              Copied!
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/pages/ListAPIKeysPage.tsx
+++ b/app/src/pages/ListAPIKeysPage.tsx
@@ -59,6 +59,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { InputTags } from "@/components/InputTags";
 import { Switch } from "@/components/ui/switch";
+import { SecretCopier } from "@/components/SecretCopier";
 
 export function ListAPIKeysPage() {
   return (
@@ -304,10 +305,10 @@ function CreateAPIKeyButton() {
 
           <div className="text-sm font-medium leading-none">API Key Secret</div>
 
-          <div className="text-xs font-mono bg-gray-100 py-2 px-4 rounded-sm border flex items-center">
-            {apiKeySecret}
-            <CopyButton copyText={apiKeySecret}></CopyButton>
-          </div>
+          <SecretCopier
+            placeholder="ssoready_sk_•••••••••••••••••••••••••"
+            secret={apiKeySecret}
+          />
 
           <AlertDialogFooter>
             <AlertDialogAction asChild>
@@ -392,16 +393,17 @@ function ListOAuthClientsCard() {
             SAML OAuth Client Secret
           </div>
 
-          <div className="text-xs font-mono bg-gray-100 py-2 px-4 rounded-sm border">
-            {samlOAuthClientSecret}
-          </div>
+          <SecretCopier
+            placeholder="ssoready_oauth_client_secret_•••••••••••••••••••••••••"
+            secret={samlOAuthClientSecret}
+          />
 
           <AlertDialogFooter>
             <AlertDialogAction asChild>
               <Link
                 to={`/environments/${environmentId}/saml-oauth-clients/${samlOAuthClientId}`}
               >
-                View SAML OAuth Client
+                Done
               </Link>
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -461,50 +463,5 @@ function ListOAuthClientsCard() {
         </CardContent>
       </Card>
     </>
-  );
-}
-
-function CopyButton({ copyText }: { copyText: string }) {
-  const [open, setOpen] = useState(false);
-  const { refs, floatingStyles, context } = useFloating({
-    open,
-    onOpenChange: setOpen,
-    placement: "top",
-    middleware: [offset(5)],
-  });
-  const { isMounted, styles } = useTransitionStyles(context);
-
-  useEffect(() => {
-    if (open) {
-      const timeoutId = setTimeout(() => {
-        setOpen(false);
-      }, 1000);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [open]);
-
-  return (
-    <div className="ml-auto">
-      <CopyIcon
-        ref={refs.setReference}
-        className="h-4 w-4 cursor-pointer text-muted-foreground"
-        onClick={async () => {
-          await navigator.clipboard.writeText(copyText);
-          setOpen(true);
-        }}
-      />
-      {open && (
-        <div ref={refs.setFloating} style={floatingStyles}>
-          {isMounted && (
-            <div
-              style={styles}
-              className="bg-black text-white p-1 text-xs rounded"
-            >
-              Copied!
-            </div>
-          )}
-        </div>
-      )}
-    </div>
   );
 }

--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -75,6 +75,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
+import { SecretCopier } from "@/components/SecretCopier";
 
 export function ViewSCIMDirectoryPage() {
   const { environmentId, organizationId, scimDirectoryId } = useParams();
@@ -161,9 +162,10 @@ export function ViewSCIMDirectoryPage() {
             SCIM Bearer Token
           </div>
 
-          <div className="text-xs font-mono bg-gray-100 py-2 px-4 rounded-sm border">
-            {bearerToken}
-          </div>
+          <SecretCopier
+            placeholder="ssoready_scim_bearer_token_•••••••••••••••••••••••••"
+            secret={bearerToken}
+          />
 
           <AlertDialogFooter>
             <AlertDialogCancel>Close</AlertDialogCancel>


### PR DESCRIPTION
This PR adds a component, `SecretCopier`, for displaying a preview of a secret, without actually revealing it in the UI. Clicking anywhere in a `SecretCopier` copies the actual underlying secret to the clipboard. It's not possible to text in the displayed preview, so it's unlikely a user would accidentally copy the placeholder.


https://github.com/user-attachments/assets/3fde1dfc-9068-4b81-a37e-50f60cc227b3

