### PR TITLE
admin: setup entra: fix bad copy referencing "Okta"

### DIFF
--- a/admin/src/pages/SetupSAMLConnectionPage.tsx
+++ b/admin/src/pages/SetupSAMLConnectionPage.tsx
@@ -1439,7 +1439,7 @@ function EntraDownloadMetadataStep() {
           <div>
             <p className="text-sm mt-4">
               Successfully imported your app's Federation Metadata XML settings
-              from Okta. The last remaining step is to assign users to your new
+              from Entra. The last remaining step is to assign users to your new
               application.
             </p>
 


### PR DESCRIPTION
Accidentally left a reference to "Okta" in the setup flow for Entra.