### PR TITLE
Fix configuration for adminproxy

### DIFF
--- a/cmd/adminproxy/fly-prod.toml
+++ b/cmd/adminproxy/fly-prod.toml
@@ -1,4 +1,4 @@
-app = 'ssoready-auth-custom-domain'
+app = 'ssoready-admin-custom-domain'
 primary_region = 'iad'
 
 [build]

--- a/cmd/adminproxy/fly-prod.toml
+++ b/cmd/adminproxy/fly-prod.toml
@@ -1,3 +1,8 @@
+# fly.toml app configuration file generated for ssoready-admin-custom-domain on 2024-09-09T13:47:28-07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
 app = 'ssoready-admin-custom-domain'
 primary_region = 'iad'
 

--- a/cmd/api/task-definition-prod.json
+++ b/cmd/api/task-definition-prod.json
@@ -69,6 +69,14 @@
           "value": "ssoready-auth-custom-domain.fly.dev."
         },
         {
+          "name": "API_FLYIO_ADMINPROXY_APP_ID",
+          "value": "ssoready-admin-custom-domain"
+        },
+        {
+          "name": "API_FLYIO_ADMINPROXY_APP_CNAME_VALUE",
+          "value": "ssoready-admin-custom-domain.fly.dev."
+        },
+        {
           "name": "API_ADMIN_LOGOS_S3_BUCKET_NAME",
           "value": "ssoready-prod-admin-logos"
         }


### PR DESCRIPTION
This PR updates the configuration we have for adminproxy. 

It now has the correct name both on the fly.io side and the api side.