### PR TITLE
app: Add tooltips + links to docs for every property on resources

### DIFF
--- a/app/.idea/app.iml
+++ b/app/.idea/app.iml
@@ -5,6 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/public" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-popover": "^1.1.1",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-switch": "^1.0.3",
@@ -881,6 +882,441 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.1.tgz",
+      "integrity": "sha512-3y1A3isulwnWhvTTwmIreiB8CF4L+qRjZnK1wYLO7pplddzXKby/GnZ2M7OZY3qgnl6p9AodUIHRYGXNah8Y7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
+      "integrity": "sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+      "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
+      "integrity": "sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/react-remove-scroll": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -10775,6 +11211,203 @@
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.5.5"
+      }
+    },
+    "@radix-ui/react-popover": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.1.tgz",
+      "integrity": "sha512-3y1A3isulwnWhvTTwmIreiB8CF4L+qRjZnK1wYLO7pplddzXKby/GnZ2M7OZY3qgnl6p9AodUIHRYGXNah8Y7g==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "dependencies": {
+        "@radix-ui/primitive": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+          "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+        },
+        "@radix-ui/react-arrow": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
+          "integrity": "sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==",
+          "requires": {
+            "@radix-ui/react-primitive": "2.0.0"
+          }
+        },
+        "@radix-ui/react-compose-refs": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+          "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+          "requires": {}
+        },
+        "@radix-ui/react-context": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+          "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+          "requires": {}
+        },
+        "@radix-ui/react-dismissable-layer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+          "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+          "requires": {
+            "@radix-ui/primitive": "1.1.0",
+            "@radix-ui/react-compose-refs": "1.1.0",
+            "@radix-ui/react-primitive": "2.0.0",
+            "@radix-ui/react-use-callback-ref": "1.1.0",
+            "@radix-ui/react-use-escape-keydown": "1.1.0"
+          }
+        },
+        "@radix-ui/react-focus-guards": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+          "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+          "requires": {}
+        },
+        "@radix-ui/react-focus-scope": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+          "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.0",
+            "@radix-ui/react-primitive": "2.0.0",
+            "@radix-ui/react-use-callback-ref": "1.1.0"
+          }
+        },
+        "@radix-ui/react-id": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+          "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.0"
+          }
+        },
+        "@radix-ui/react-popper": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
+          "integrity": "sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==",
+          "requires": {
+            "@floating-ui/react-dom": "^2.0.0",
+            "@radix-ui/react-arrow": "1.1.0",
+            "@radix-ui/react-compose-refs": "1.1.0",
+            "@radix-ui/react-context": "1.1.0",
+            "@radix-ui/react-primitive": "2.0.0",
+            "@radix-ui/react-use-callback-ref": "1.1.0",
+            "@radix-ui/react-use-layout-effect": "1.1.0",
+            "@radix-ui/react-use-rect": "1.1.0",
+            "@radix-ui/react-use-size": "1.1.0",
+            "@radix-ui/rect": "1.1.0"
+          }
+        },
+        "@radix-ui/react-portal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+          "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+          "requires": {
+            "@radix-ui/react-primitive": "2.0.0",
+            "@radix-ui/react-use-layout-effect": "1.1.0"
+          }
+        },
+        "@radix-ui/react-presence": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+          "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.0",
+            "@radix-ui/react-use-layout-effect": "1.1.0"
+          }
+        },
+        "@radix-ui/react-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+          "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+          "requires": {
+            "@radix-ui/react-slot": "1.1.0"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+          "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.0"
+          }
+        },
+        "@radix-ui/react-use-callback-ref": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+          "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+          "requires": {}
+        },
+        "@radix-ui/react-use-controllable-state": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+          "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+          "requires": {
+            "@radix-ui/react-use-callback-ref": "1.1.0"
+          }
+        },
+        "@radix-ui/react-use-escape-keydown": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+          "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+          "requires": {
+            "@radix-ui/react-use-callback-ref": "1.1.0"
+          }
+        },
+        "@radix-ui/react-use-layout-effect": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+          "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+          "requires": {}
+        },
+        "@radix-ui/react-use-rect": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+          "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+          "requires": {
+            "@radix-ui/rect": "1.1.0"
+          }
+        },
+        "@radix-ui/react-use-size": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+          "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.0"
+          }
+        },
+        "@radix-ui/rect": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+          "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
+        },
+        "react-remove-scroll": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+          "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+          "requires": {
+            "react-remove-scroll-bar": "^2.3.4",
+            "react-style-singleton": "^2.2.1",
+            "tslib": "^2.1.0",
+            "use-callback-ref": "^1.3.0",
+            "use-sidecar": "^1.1.2"
+          }
+        }
       }
     },
     "@radix-ui/react-popper": {

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",

--- a/app/src/components/InfoTooltip.tsx
+++ b/app/src/components/InfoTooltip.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { InfoIcon } from "lucide-react";
+
+export function InfoTooltip({ children }: { children: ReactNode }) {
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <InfoIcon className="h-4 w-4" />
+      </PopoverTrigger>
+      <PopoverContent side="top" className="text-xs">
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/src/components/ui/popover.tsx
+++ b/app/src/components/ui/popover.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/app/src/pages/ListAPIKeysPage.tsx
+++ b/app/src/pages/ListAPIKeysPage.tsx
@@ -61,6 +61,7 @@ import { InputTags } from "@/components/InputTags";
 import { Switch } from "@/components/ui/switch";
 import { SecretCopier } from "@/components/SecretCopier";
 import { Title } from "@/components/Title";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ListAPIKeysPage() {
   return (
@@ -99,6 +100,7 @@ function ListAPIKeysCard() {
                 An API key is how your application authenticates with SSOReady's
                 SDKs or REST APIs. Most SSOReady users should use these over
                 SAML OAuth Clients.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#api-keys" />
               </CardDescription>
             </div>
 
@@ -423,6 +425,7 @@ function ListOAuthClientsCard() {
                 exclusively uses OAuth to do user logins. Use these if
                 interacting directly with SSOReady using an API Key isn't an
                 option for you.
+                <DocsLink to="https://ssoready.com/docs/saml-over-oauth-saml-nextauth-integration" />
               </CardDescription>
             </div>
 

--- a/app/src/pages/ViewAPIKeyPage.tsx
+++ b/app/src/pages/ViewAPIKeyPage.tsx
@@ -15,6 +15,8 @@ import { useNavigate, useParams } from "react-router";
 import { Heading } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Title } from "@/components/Title";
+import { InfoTooltip } from "@/components/InfoTooltip";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewAPIKeyPage() {
   const { environmentId, apiKeyId } = useParams();
@@ -48,14 +50,19 @@ export function ViewAPIKeyPage() {
               <CardDescription>
                 An API key is how your application authenticates with SSOReady's
                 SDKs or REST APIs.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#api-keys" />
               </CardDescription>
             </div>
           </div>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Management API Access
+              <InfoTooltip>
+                Whether this API key can use the Management API.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#management-api" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {apiKey?.hasManagementApiAccess ? "Yes" : "No"}

--- a/app/src/pages/ViewBrandingSettingsPage.tsx
+++ b/app/src/pages/ViewBrandingSettingsPage.tsx
@@ -51,6 +51,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Link } from "react-router-dom";
 import { Title } from "@/components/Title";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewBrandingSettingsPage() {
   const { environmentId } = useParams();
@@ -79,23 +80,32 @@ export function ViewBrandingSettingsPage() {
             SSOReady can host a UI on your behalf that lets your customers
             configure their SAML and SCIM settings on their own. Here, you can
             make that UI look on-brand for your company.
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#custom-branding" />
           </CardDescription>
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2 items-center">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2 items-center">
+            <div className="text-sm col-span-2 text-muted-foreground">
               Application Name
             </div>
             <div className="text-sm col-span-3">
-              {environmentAdminSettings?.adminApplicationName}
+              {environmentAdminSettings?.adminApplicationName || (
+                <div className="text-sm text-muted-foreground">
+                  Not configured
+                </div>
+              )}
             </div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground">
               Return URL
             </div>
             <div className="text-sm col-span-3">
-              {environmentAdminSettings?.adminReturnUrl}
+              {environmentAdminSettings?.adminReturnUrl || (
+                <div className="text-sm text-muted-foreground">
+                  Not configured
+                </div>
+              )}
             </div>
           </div>
         </CardContent>

--- a/app/src/pages/ViewCustomDomainsPage.tsx
+++ b/app/src/pages/ViewCustomDomainsPage.tsx
@@ -54,6 +54,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { GetEnvironmentCustomDomainSettingsResponse } from "@/gen/ssoready/v1/ssoready_pb";
 import { Title } from "@/components/Title";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewCustomDomainsPage() {
   const { environmentId } = useParams();
@@ -114,6 +115,7 @@ export function ViewCustomDomainsPage() {
             customer's Identity Provider talks to. SSOReady runs that server for
             you. By default, it's hosted at auth.ssoready.com. With a custom
             domain, you can run it on any domain you control.
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#running-authssoreadycom-on-a-custom-domain" />
           </CardDescription>
         </CardHeader>
 
@@ -272,6 +274,7 @@ export function ViewCustomDomainsPage() {
             set-up process for SAML Connections and SCIM Directories. By
             default, it's hosted at admin.ssoready.com. With a custom domain,
             you can run it on any domain you control.
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#running-adminssoreadycom-on-a-custom-domain" />
           </CardDescription>
         </CardHeader>
 

--- a/app/src/pages/ViewEnvironmentPage.tsx
+++ b/app/src/pages/ViewEnvironmentPage.tsx
@@ -136,7 +136,7 @@ export function ViewEnvironmentPage() {
               <InfoTooltip>
                 Where SSOReady will redirect your users if you use
                 SAML-over-OAuth.
-                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#redirect-url" />
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#oauth-redirect-uri" />
               </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
@@ -151,7 +151,7 @@ export function ViewEnvironmentPage() {
               <InfoTooltip>
                 The URL your customers see instead of{" "}
                 <span className="font-mono">auth.ssoready.com</span>.
-                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#redirect-url" />
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#custom-ssoready-auth-url" />
               </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">

--- a/app/src/pages/ViewEnvironmentPage.tsx
+++ b/app/src/pages/ViewEnvironmentPage.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { DocsLink } from "@/components/DocsLink";
 import { Title } from "@/components/Title";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewEnvironmentPage() {
   const { environmentId } = useParams();
@@ -109,6 +110,7 @@ export function ViewEnvironmentPage() {
               <CardDescription>
                 An environment corresponds to a deployment environment in your
                 product, e.g. "Staging" or "Production".
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments" />
               </CardDescription>
             </div>
 
@@ -119,13 +121,23 @@ export function ViewEnvironmentPage() {
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Redirect URL
+              <InfoTooltip>
+                Where SSOReady will redirect your users after they log in via
+                SAML.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#redirect-url" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">{environment?.redirectUrl}</div>
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               OAuth Redirect URI
+              <InfoTooltip>
+                Where SSOReady will redirect your users if you use
+                SAML-over-OAuth.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#redirect-url" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {environment?.oauthRedirectUri ? (
@@ -134,10 +146,21 @@ export function ViewEnvironmentPage() {
                 <span className="text-muted-foreground">Not configured</span>
               )}
             </div>
-            <div className="text-sm col-span-1 text-muted-foreground">
-              Custom SSOReady Auth URL
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
+              Custom auth.ssoready.com domain
+              <InfoTooltip>
+                The URL your customers see instead of{" "}
+                <span className="font-mono">auth.ssoready.com</span>.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/environments#redirect-url" />
+              </InfoTooltip>
             </div>
-            <div className="text-sm col-span-3">{environment?.authUrl}</div>
+            <div className="text-sm col-span-3">
+              {environment?.authUrl ? (
+                <span>{environment.authUrl}</span>
+              ) : (
+                <span className="text-muted-foreground">Not configured</span>
+              )}
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/app/src/pages/ViewOrganizationPage.tsx
+++ b/app/src/pages/ViewOrganizationPage.tsx
@@ -80,6 +80,7 @@ import { DocsLink } from "@/components/DocsLink";
 import { Switch } from "@/components/ui/switch";
 import { SecretCopier } from "@/components/SecretCopier";
 import { Title } from "@/components/Title";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewOrganizationPage() {
   const { environmentId, organizationId } = useParams();
@@ -150,6 +151,7 @@ export function ViewOrganizationPage() {
 
               <CardDescription>
                 An organization corresponds to a tenant in your application.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/organizations" />
               </CardDescription>
             </div>
 
@@ -160,14 +162,23 @@ export function ViewOrganizationPage() {
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               External ID
+              <InfoTooltip>
+                Optional. An ID from your database for this organization.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/organizations#organization-external-id" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">{organization?.externalId}</div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Domains
+              <InfoTooltip>
+                A whitelist of domains that customers from this organization
+                use.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/organizations#domains" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {" "}
@@ -295,9 +306,9 @@ function AdminSetupURLCard() {
     <>
       <Card>
         <CardHeader>
-          <CardTitle className="flex gap-x-4 items-center">
-            <span>Customer self-serve setup</span>
-            <Badge variant="secondary">Beta</Badge>
+          <CardTitle>
+            Customer self-serve setup
+            <DocsLink to="https://ssoready.com/docs/idp-configuration/enabling-self-service-configuration-for-your-customers" />
           </CardTitle>
           <CardDescription>
             You can invite your customer's IT admin to set up their SAML
@@ -578,9 +589,9 @@ function OrganizationSCIMDirectoriesPage() {
       <CardHeader>
         <div className="flex justify-between items-center">
           <div className="flex flex-col space-y-1.5">
-            <CardTitle className="flex gap-x-4 items-center">
-              <span>SCIM Directories</span>
-              <Badge variant="secondary">Beta</Badge>
+            <CardTitle>
+              SCIM Directories
+              <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-directories" />
             </CardTitle>
             <CardDescription>
               SCIM Directories within this organization.

--- a/app/src/pages/ViewSAMLConnectionPage.tsx
+++ b/app/src/pages/ViewSAMLConnectionPage.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft } from "lucide-react";
+import { ArrowDownUpIcon, ChevronLeft } from "lucide-react";
 import { Link } from "react-router-dom";
 import {
   Table,
@@ -76,6 +76,7 @@ import { InputTags } from "@/components/InputTags";
 import { Switch } from "@/components/ui/switch";
 import { DocsLink } from "@/components/DocsLink";
 import { Title } from "@/components/Title";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewSAMLConnectionPage() {
   const { environmentId, organizationId, samlConnectionId } = useParams();
@@ -123,6 +124,7 @@ export function ViewSAMLConnectionPage() {
               <CardDescription>
                 A SAML connection is a link between your product and your
                 customer's Identity Provider.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections" />
               </CardDescription>
             </div>
 
@@ -137,9 +139,14 @@ export function ViewSAMLConnectionPage() {
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Primary
+              <InfoTooltip>
+                A "primary" SAML connection gets used by default within its
+                organization.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#primary" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {samlConnection?.primary ? "Yes" : "No"}
@@ -168,7 +175,10 @@ export function ViewSAMLConnectionPage() {
         <TabsContent value="config">
           <Card>
             <CardHeader>
-              <CardTitle>Service Provider Configuration</CardTitle>
+              <CardTitle>
+                Service Provider Configuration
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#service-provider-configuration" />
+              </CardTitle>
               <CardDescription>
                 The configuration here is assigned automatically by SSOReady,
                 and needs to be inputted into your customer's Identity Provider
@@ -176,16 +186,25 @@ export function ViewSAMLConnectionPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-4 gap-y-2 items-center">
-                <div className="text-sm col-span-1 text-muted-foreground">
+              <div className="grid grid-cols-5 gap-y-2 items-center">
+                <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
                   Assertion Consumer Service (ACS) URL
+                  <InfoTooltip>
+                    An HTTP endpoint that receives SAML assertions.
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#assertion-consumer-service-acs-url" />
+                  </InfoTooltip>
                 </div>
                 <div className="text-sm col-span-3">
                   {samlConnection?.spAcsUrl}
                 </div>
 
-                <div className="text-sm col-span-1 text-muted-foreground">
+                <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
                   SP Entity ID
+                  <InfoTooltip>
+                    An identifier indicating which application a SAML assertion
+                    is intended for.
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#sp-entity-id" />
+                  </InfoTooltip>
                 </div>
                 <div className="text-sm col-span-3">
                   {samlConnection?.spEntityId}
@@ -198,10 +217,13 @@ export function ViewSAMLConnectionPage() {
             <CardHeader>
               <div className="flex justify-between items-center">
                 <div className="flex flex-col space-y-1.5">
-                  <CardTitle>Identity Provider Configuration</CardTitle>
+                  <CardTitle>
+                    Identity Provider Configuration
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#identity-provider-configuration" />
+                  </CardTitle>
                   <CardDescription>
                     The configuration here needs to be copied over from the
-                    customer's Identity Provider.
+                    customer's Identity Provider ("IDP").
                   </CardDescription>
                 </div>
 
@@ -213,33 +235,58 @@ export function ViewSAMLConnectionPage() {
               </div>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-4 gap-y-2 items-center">
-                <div className="text-sm col-span-1 text-muted-foreground">
+              <div className="grid grid-cols-5 gap-y-2 items-center">
+                <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
                   IDP Entity ID
+                  <InfoTooltip>
+                    An identifier the IDP assigns for the SAML connection.
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#idp-entity-id" />
+                  </InfoTooltip>
                 </div>
                 <div className="text-sm col-span-3">
-                  {samlConnection?.idpEntityId}
+                  {samlConnection?.idpEntityId || (
+                    <div className="text-sm text-muted-foreground">
+                      Not configured
+                    </div>
+                  )}
                 </div>
-                <div className="text-sm col-span-1 text-muted-foreground">
+                <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
                   Redirect URL
+                  <InfoTooltip>
+                    An HTTP endpoint on the IDP that accepts SAML initiation
+                    requests.
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#redirect-url" />
+                  </InfoTooltip>
                 </div>
                 <div className="text-sm col-span-3">
-                  {samlConnection?.idpRedirectUrl}
+                  {samlConnection?.idpRedirectUrl || (
+                    <div className="text-sm text-muted-foreground">
+                      Not configured
+                    </div>
+                  )}
+                </div>
+
+                <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2 self-start">
+                  Certificate
+                  <InfoTooltip>
+                    An X.509 certificate the IDP uses to sign assertions.
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-connections#certificate" />
+                  </InfoTooltip>
+                </div>
+                <div className="text-sm col-span-3">
+                  {samlConnection?.idpCertificate ? (
+                    <div className="bg-black rounded-lg px-6 py-4 mt-4 inline-block">
+                      <code className="text-sm text-white">
+                        <pre>{samlConnection?.idpCertificate}</pre>
+                      </code>
+                    </div>
+                  ) : (
+                    <div className="text-sm text-muted-foreground">
+                      Not configured
+                    </div>
+                  )}
                 </div>
               </div>
-
-              <Collapsible className="mt-1.5">
-                <CollapsibleTrigger className="text-sm text-muted-foreground">
-                  Certificate (click to show)
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <div className="bg-black rounded-lg px-6 py-4 mt-4 inline-block">
-                    <code className="text-sm text-white">
-                      <pre>{samlConnection?.idpCertificate}</pre>
-                    </code>
-                  </div>
-                </CollapsibleContent>
-              </Collapsible>
             </CardContent>
           </Card>
         </TabsContent>

--- a/app/src/pages/ViewSAMLFlowPage.tsx
+++ b/app/src/pages/ViewSAMLFlowPage.tsx
@@ -29,6 +29,8 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { OctagonX } from "lucide-react";
 import { Title } from "@/components/Title";
+import { DocsLink } from "@/components/DocsLink";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewSAMLFlowPage() {
   const { environmentId, organizationId, samlConnectionId, samlFlowId } =
@@ -78,7 +80,7 @@ export function ViewSAMLFlowPage() {
           <div className="flex justify-between items-center">
             <div className="flex flex-col space-y-1.5">
               <div className="flex gap-4">
-                <CardTitle>SAML Flow</CardTitle>
+                <CardTitle>SAML Login Flow</CardTitle>
 
                 <span className="text-xs font-mono bg-gray-100 py-1 px-2 rounded-sm">
                   {samlFlowId}
@@ -86,33 +88,47 @@ export function ViewSAMLFlowPage() {
               </div>
 
               <CardDescription>
-                A SAML flow is a single time one of your users attempted to log
-                in via SAML.
+                A SAML login flow is a single time one of your users attempted
+                to log in via SAML.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows" />
               </CardDescription>
             </div>
           </div>
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Started
+              <InfoTooltip>
+                When the login process began.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#start-time" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {samlFlow?.createTime &&
                 moment(samlFlow.createTime.toDate()).format()}
             </div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Last Activity
+              <InfoTooltip>
+                The last time any progress has happened on the SAML login flow.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#last-activity-time" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {samlFlow?.updateTime &&
                 moment(samlFlow.updateTime.toDate()).format()}
             </div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Status
+              <InfoTooltip>
+                Whether the SAML login flow is in progress, succeeded, or
+                failed.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#status" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {samlFlow?.status ===
@@ -128,24 +144,41 @@ export function ViewSAMLFlowPage() {
               )}
             </div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               State
+              <InfoTooltip>
+                The <code>state</code> you provided when getting a SAML redirect
+                URL.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#state" />
+              </InfoTooltip>
             </div>
-            <div className="text-sm col-span-3">
-              <span className="font-mono bg-gray-100 py-1 px-2 rounded-sm">
-                {samlFlow?.state}
-              </span>
+            <div className="col-span-3">
+              {samlFlow?.state ? (
+                <span className="text-xs font-mono bg-gray-100 py-1 px-2 rounded-sm">
+                  {samlFlow.state}
+                </span>
+              ) : (
+                <span className="text-sm text-muted-foreground">None</span>
+              )}
             </div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               User Email
+              <InfoTooltip>
+                Your end user's email address.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#user-email" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">{samlFlow?.email}</div>
 
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               User Attributes
+              <InfoTooltip>
+                Additional user attributes the IDP passed along.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#user-attributes" />
+              </InfoTooltip>
             </div>
-            <div className="text-sm col-span-3">
+            <div className="text-xs col-span-3">
               <span className="font-mono bg-gray-100 py-1 px-2 rounded-sm">
                 {JSON.stringify(samlFlow?.attributes)}
               </span>
@@ -243,6 +276,7 @@ export function ViewSAMLFlowPage() {
                   </span>
                   <span className="text-sm font-semibold">
                     Requested SAML Redirect URL
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#requested-saml-redirect-url" />
                   </span>
                 </div>
 
@@ -261,6 +295,7 @@ export function ViewSAMLFlowPage() {
                   </span>
                   <span className="text-sm font-semibold">
                     Initiated SAML Flow
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#initiated-saml-flow" />
                   </span>
                 </div>
 
@@ -290,6 +325,7 @@ export function ViewSAMLFlowPage() {
                   </span>
                   <span className="text-sm font-semibold">
                     Received SAML Assertion
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#received-saml-assertion" />
                   </span>
                 </div>
 
@@ -316,6 +352,7 @@ export function ViewSAMLFlowPage() {
                   </span>
                   <span className="text-sm font-semibold">
                     Redeemed SAML Access Code
+                    <DocsLink to="https://ssoready.com/docs/ssoready-concepts/saml-login-flows#redeemed-saml-access-code" />
                   </span>
                 </div>
 

--- a/app/src/pages/ViewSAMLOAuthClientPage.tsx
+++ b/app/src/pages/ViewSAMLOAuthClientPage.tsx
@@ -15,6 +15,7 @@ import { useNavigate, useParams } from "react-router";
 import { Heading } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Title } from "@/components/Title";
+import { DocsLink } from "@/components/DocsLink";
 
 export function ViewSAMLOAuthClientPage() {
   const { environmentId, samlOAuthClientId } = useParams();
@@ -55,6 +56,7 @@ export function ViewSAMLOAuthClientPage() {
               <CardDescription>
                 A SAML OAuth client is a way to add SAML support to an app that
                 exclusively uses OAuth to do user logins.
+                <DocsLink to="https://ssoready.com/docs/saml-over-oauth-saml-nextauth-integration" />
               </CardDescription>
             </div>
           </div>

--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -77,6 +77,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { SecretCopier } from "@/components/SecretCopier";
 import { Title } from "@/components/Title";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewSCIMDirectoryPage() {
   const { environmentId, organizationId, scimDirectoryId } = useParams();
@@ -210,6 +211,7 @@ export function ViewSCIMDirectoryPage() {
                 <CardDescription>
                   A SCIM directory is a connection between your product and your
                   customer's employee directory.
+                  <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-directories" />
                 </CardDescription>
               </div>
 
@@ -222,15 +224,25 @@ export function ViewSCIMDirectoryPage() {
           </CardHeader>
 
           <CardContent>
-            <div className="grid grid-cols-4 gap-y-2">
-              <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="grid grid-cols-5 gap-y-2">
+              <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
                 Primary
+                <InfoTooltip>
+                  A "primary" SCIM directory gets used by default within its
+                  organization.
+                  <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-directories#primary" />
+                </InfoTooltip>
               </div>
               <div className="text-sm col-span-3">
                 {scimDirectory?.primary ? "Yes" : "No"}
               </div>
-              <div className="text-sm col-span-1 text-muted-foreground">
+              <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
                 SCIM Base URL
+                <InfoTooltip>
+                  The base URL your customer's IDP uses to send SCIM HTTP
+                  requests.
+                  <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-directories#scim-base-url" />
+                </InfoTooltip>
               </div>
               <div className="text-sm col-span-3">
                 {scimDirectory?.scimBaseUrl}
@@ -241,7 +253,10 @@ export function ViewSCIMDirectoryPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>SCIM Authentication</CardTitle>
+            <CardTitle>
+              SCIM Authentication
+              <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-directories#scim-authentication" />
+            </CardTitle>
             <CardDescription>
               To set up SCIM, your customer's IT admin will need to configure a
               Bearer authentication token in their Identity Provider. You can
@@ -404,7 +419,10 @@ function UsersTabContent() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>SCIM Users</CardTitle>
+        <CardTitle>
+          SCIM Users
+          <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-users" />
+        </CardTitle>
         <CardDescription>
           Users belonging to this SCIM directory.
         </CardDescription>
@@ -467,7 +485,10 @@ function GroupsTabContent() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>SCIM Groups</CardTitle>
+        <CardTitle>
+          SCIM Groups
+          <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups" />
+        </CardTitle>
         <CardDescription>
           Groups belonging to this SCIM directory.
         </CardDescription>

--- a/app/src/pages/ViewSCIMGroupPage.tsx
+++ b/app/src/pages/ViewSCIMGroupPage.tsx
@@ -33,6 +33,8 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Title } from "@/components/Title";
+import { DocsLink } from "@/components/DocsLink";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewSCIMGroupPage() {
   const { environmentId, organizationId, scimDirectoryId, scimGroupId } =
@@ -100,19 +102,28 @@ export function ViewSCIMGroupPage() {
               <CardDescription>
                 A SCIM group is one of your customer's employees, synced in from
                 their configured SCIM directory.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups" />
               </CardDescription>
             </div>
           </div>
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Display Name
+              <InfoTooltip>
+                A human-friendly name.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups#display-name" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">{scimGroup?.displayName}</div>
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Deleted
+              <InfoTooltip>
+                Whether the group has been deleted or deprovisioned.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups#deleted" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {scimGroup?.deleted ? "Yes" : "No"}
@@ -123,7 +134,10 @@ export function ViewSCIMGroupPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Group Details</CardTitle>
+          <CardTitle>
+            Group Details
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups#attributes" />
+          </CardTitle>
           <CardDescription>
             Your customers, depending on their Identity Provider vendor and
             configuration, will likely have a different set of{" "}
@@ -158,7 +172,10 @@ export function ViewSCIMGroupPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>SCIM Users</CardTitle>
+          <CardTitle>
+            SCIM Users
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups#users" />
+          </CardTitle>
           <CardDescription>Users belonging to this SCIM group.</CardDescription>
         </CardHeader>
         <CardContent>

--- a/app/src/pages/ViewSCIMUserPage.tsx
+++ b/app/src/pages/ViewSCIMUserPage.tsx
@@ -33,6 +33,9 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Title } from "@/components/Title";
+import { Dock } from "lucide-react";
+import { DocsLink } from "@/components/DocsLink";
+import { InfoTooltip } from "@/components/InfoTooltip";
 
 export function ViewSCIMUserPage() {
   const { environmentId, organizationId, scimDirectoryId, scimUserId } =
@@ -100,19 +103,28 @@ export function ViewSCIMUserPage() {
               <CardDescription>
                 A SCIM user is one of your customer's employees, synced in from
                 their configured SCIM directory.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-users" />
               </CardDescription>
             </div>
           </div>
         </CardHeader>
 
         <CardContent>
-          <div className="grid grid-cols-4 gap-y-2">
-            <div className="text-sm col-span-1 text-muted-foreground">
+          <div className="grid grid-cols-5 gap-y-2">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Email
+              <InfoTooltip>
+                Your end user's email address.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-users#email" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">{scimUser?.email}</div>
-            <div className="text-sm col-span-1 text-muted-foreground">
+            <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Deleted
+              <InfoTooltip>
+                Whether the user has been deleted or deprovisioned.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-users#deleted" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {scimUser?.deleted ? "Yes" : "No"}
@@ -123,7 +135,10 @@ export function ViewSCIMUserPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>User Details</CardTitle>
+          <CardTitle>
+            User Details
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-users#attributes" />
+          </CardTitle>
           <CardDescription>
             Your customers, depending on their Identity Provider vendor and
             configuration, will likely have a different set of{" "}
@@ -158,7 +173,10 @@ export function ViewSCIMUserPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>SCIM Groups</CardTitle>
+          <CardTitle>
+            SCIM Groups
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups" />
+          </CardTitle>
           <CardDescription>
             SCIM groups this SCIM user belongs to.
           </CardDescription>

--- a/app/src/pages/ViewSCIMUserPage.tsx
+++ b/app/src/pages/ViewSCIMUserPage.tsx
@@ -175,7 +175,7 @@ export function ViewSCIMUserPage() {
         <CardHeader>
           <CardTitle>
             SCIM Groups
-            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-groups" />
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-users#groups" />
           </CardTitle>
           <CardDescription>
             SCIM groups this SCIM user belongs to.


### PR DESCRIPTION
This PR passes over all places we display the various entities in SSOReady (envs, orgs, saml conns, etc.) and adds links to docs where appropriate. Every property on objects now has a tooltip that very briefly describes the property and links to the relevant section in the docs.

Showing screenshots of every page would be a bit tedious, so here's a representative example of the new look:

<img width="1624" alt="Screenshot 2024-09-10 at 3 06 31 PM" src="https://github.com/user-attachments/assets/291ebf0a-5288-4382-a68e-a69283493897">

<img width="1624" alt="Screenshot 2024-09-10 at 3 06 36 PM" src="https://github.com/user-attachments/assets/55d610dc-2474-45b6-b07c-554df362c622">
