### PR TITLE
scim: add links to docs in app, give better error messages over http for bad bearer tokens

### DIFF
--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -554,7 +554,10 @@ function RequestsCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>SCIM Request Log</CardTitle>
+        <CardTitle>
+          SCIM Request Logs
+          <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs" />
+        </CardTitle>
         <CardDescription>
           SCIM requests your customer's IDP has issued to SSOReady, and how we
           responded.

--- a/app/src/pages/ViewSCIMRequestPage.tsx
+++ b/app/src/pages/ViewSCIMRequestPage.tsx
@@ -87,6 +87,7 @@ export function ViewSCIMRequestPage() {
                 A SCIM request log is a record of a SCIM HTTP request sent by
                 your customer's identity provider to SSOReady, and how SSOReady
                 responded.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs" />
               </CardDescription>
             </div>
           </div>
@@ -95,6 +96,10 @@ export function ViewSCIMRequestPage() {
           <div className="grid grid-cols-5 gap-y-2">
             <div className="text-sm col-span-2 text-muted-foreground flex items-center gap-x-2">
               Timestamp
+              <InfoTooltip>
+                When the SCIM request occurred.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs#timestamp" />
+              </InfoTooltip>
             </div>
             <div className="text-sm col-span-3">
               {scimRequest?.scimRequest &&
@@ -117,6 +122,7 @@ export function ViewSCIMRequestPage() {
                 This request had an incorrect bearer token. SSOReady could not
                 authenticate that this request really came from your customer's
                 identity provider.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs#bad-bearer-token" />
               </p>
 
               <p className="mt-4">
@@ -149,6 +155,7 @@ export function ViewSCIMRequestPage() {
                 </span>
                 , which is invalid. SSOReady requires that SCIM usernames be
                 email addresses.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs#bad-username" />
               </p>
             </AlertDescription>
           )}
@@ -163,6 +170,7 @@ export function ViewSCIMRequestPage() {
                   {scimRequest.scimRequest.error.value}
                 </span>
                 , which is outside of the organization allowed domains.
+                <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs#email-outside-organization-domains" />
               </p>
             </AlertDescription>
           )}
@@ -171,7 +179,10 @@ export function ViewSCIMRequestPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>HTTP Request</CardTitle>
+          <CardTitle>
+            HTTP Request
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs#http-request-details" />
+          </CardTitle>
           <CardDescription>
             Details about the SCIM HTTP request. This was sent from your
             customer's identity provider to SSOReady.
@@ -196,7 +207,10 @@ export function ViewSCIMRequestPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>HTTP Response</CardTitle>
+          <CardTitle>
+            HTTP Response
+            <DocsLink to="https://ssoready.com/docs/ssoready-concepts/scim-request-logs#http-response-details" />
+          </CardTitle>
           <CardDescription>
             Details about the SCIM HTTP response. This was SSOReady's reply to
             your customer's identity provider.

--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -837,7 +837,7 @@ func (s *Service) scimMiddleware(f func(w http.ResponseWriter, r *http.Request) 
 					panic(err)
 				}
 
-				http.Error(w, "invalid bearer token from middleware", http.StatusUnauthorized)
+				http.Error(w, "invalid bearer token", http.StatusUnauthorized)
 				return
 			}
 

--- a/internal/store/auth_scim.go
+++ b/internal/store/auth_scim.go
@@ -57,7 +57,7 @@ func (s *Store) AuthSCIMVerifyBearerToken(ctx context.Context, scimDirectoryID, 
 
 	bearerTokenID, err := idformat.SCIMBearerToken.Parse(bearerToken)
 	if err != nil {
-		return fmt.Errorf("parse bearer token: %w", err)
+		return ErrAuthSCIMBadBearerToken
 	}
 
 	bearerTokenSHA := sha256.Sum256(bearerTokenID[:])


### PR DESCRIPTION
This PR adds links to docs for SCIM requests. It also has SCIM requests lacking a bearer token entirely, as well as those with a malformed (i.e. not even shaped like the kind SSOReady creates) bearer token.

![screenshot-2024-09-16-10-02-46](https://github.com/user-attachments/assets/9e3c6250-ba82-4a49-8cde-352b3f3fcf2c)
