### PR TITLE
internal/saml/dsig: remove stray log

### DIFF
--- a/internal/saml/dsig/dsig.go
+++ b/internal/saml/dsig/dsig.go
@@ -52,8 +52,6 @@ func Verify(cert *x509.Certificate, data []byte) error {
 		return err
 	}
 
-	fmt.Printf("%+v\n", res)
-
 	if res.Assertion.Signature.SignatureValue == "" {
 		return ErrUnsigned
 	}


### PR DESCRIPTION
This PR removes a stray debugging log in internal/saml/dsig.