### PR TITLE
auth: simplify state query parameter signing and discontinue internal use of RelayState

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ssoready/ssoready/internal/authn"
 	ssoreadyv1 "github.com/ssoready/ssoready/internal/gen/ssoready/v1"
 	"github.com/ssoready/ssoready/internal/saml"
-	"github.com/ssoready/ssoready/internal/statesign"
 	"github.com/ssoready/ssoready/internal/store"
 	"github.com/ssoready/ssoready/internal/store/idformat"
 )
@@ -129,9 +128,6 @@ func (s *Service) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	if err := acsTemplate.Execute(w, &acsTemplateData{
 		SignOnURL:   dataRes.IDPRedirectURL,
 		SAMLRequest: initRes.SAMLRequest,
-		RelayState: s.StateSigner.Encode(statesign.Data{
-			SAMLFlowID: samlFlowID,
-		}),
 	}); err != nil {
 		panic(fmt.Errorf("acsTemplate.Execute: %w", err))
 	}

--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -25,7 +25,6 @@ import (
 type acsTemplateData struct {
 	SignOnURL   string
 	SAMLRequest string
-	RelayState  string
 }
 
 var acsTemplate = template.Must(template.New("acs").Parse(`
@@ -33,7 +32,6 @@ var acsTemplate = template.Must(template.New("acs").Parse(`
 	<body>
 		<form method="POST" action="{{ .SignOnURL }}">
 			<input type="hidden" name="SAMLRequest" value="{{ .SAMLRequest }}"></input>
-			<input type="hidden" name="RelayState" value="{{ .RelayState }}"></input>
 		</form>
 		<script>
 			document.forms[0].submit();
@@ -133,7 +131,6 @@ func (s *Service) samlInit(w http.ResponseWriter, r *http.Request) {
 	if err := acsTemplate.Execute(w, &acsTemplateData{
 		SignOnURL:   dataRes.IDPRedirectURL,
 		SAMLRequest: initRes.SAMLRequest,
-		RelayState:  state,
 	}); err != nil {
 		panic(fmt.Errorf("acsTemplate.Execute: %w", err))
 	}

--- a/internal/statesign/statesign.go
+++ b/internal/statesign/statesign.go
@@ -14,12 +14,12 @@ type Signer struct {
 }
 
 type Data struct {
-	SAMLFlowID string
-	State      string
+	SAMLConnectionID string
+	SAMLFlowID       string
 }
 
 func (signer *Signer) Encode(d Data) string {
-	payload := fmt.Sprintf("%s.%s", d.SAMLFlowID, base64.RawURLEncoding.EncodeToString([]byte(d.State)))
+	payload := fmt.Sprintf("%s.%s", d.SAMLConnectionID, d.SAMLFlowID)
 	digest := auth.Sum([]byte(payload), &signer.Key)
 	return fmt.Sprintf("%s.%s", base64.RawURLEncoding.EncodeToString([]byte(payload)), base64.RawURLEncoding.EncodeToString(digest[:]))
 }

--- a/internal/statesign/statesign.go
+++ b/internal/statesign/statesign.go
@@ -1,7 +1,6 @@
 package statesign
 
 import (
-	"bytes"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -14,14 +13,12 @@ type Signer struct {
 }
 
 type Data struct {
-	SAMLConnectionID string
-	SAMLFlowID       string
+	SAMLFlowID string
 }
 
 func (signer *Signer) Encode(d Data) string {
-	payload := fmt.Sprintf("%s.%s", d.SAMLConnectionID, d.SAMLFlowID)
-	digest := auth.Sum([]byte(payload), &signer.Key)
-	return fmt.Sprintf("%s.%s", base64.RawURLEncoding.EncodeToString([]byte(payload)), base64.RawURLEncoding.EncodeToString(digest[:]))
+	digest := auth.Sum([]byte(d.SAMLFlowID), &signer.Key)
+	return fmt.Sprintf("%s.%s", base64.RawURLEncoding.EncodeToString([]byte(d.SAMLFlowID)), base64.RawURLEncoding.EncodeToString(digest[:]))
 }
 
 func (signer *Signer) Decode(s string) (*Data, error) {
@@ -44,15 +41,5 @@ func (signer *Signer) Decode(s string) (*Data, error) {
 		return nil, fmt.Errorf("invalid signature: digest mismatch")
 	}
 
-	samlFlowID, stateBase64, ok := bytes.Cut(payload, []byte("."))
-	if !ok {
-		return nil, fmt.Errorf("invalid signature: missing '.' in payload")
-	}
-
-	state, err := base64.RawURLEncoding.DecodeString(string(stateBase64))
-	if err != nil {
-		return nil, fmt.Errorf("invalid signature: parse state: %w", err)
-	}
-
-	return &Data{SAMLFlowID: string(samlFlowID), State: string(state)}, nil
+	return &Data{SAMLFlowID: string(payload)}, nil
 }

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -85,7 +85,6 @@ func (s *Store) AuthUpsertInitiateData(ctx context.Context, req *AuthUpsertIniti
 		ID:               samlFlowID,
 		SamlConnectionID: qSAMLFlow.SamlConnectionID,
 		ExpireTime:       time.Now().Add(time.Hour),
-		State:            stateData.State,
 		CreateTime:       time.Now(),
 		UpdateTime:       time.Now(),
 		InitiateRequest:  &req.InitiateRequest,

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -46,6 +46,20 @@ func (s *Store) AuthGetInitData(ctx context.Context, req *AuthGetInitDataRequest
 		return nil, err
 	}
 
+	samlFlowID, err := idformat.SAMLFlow.Parse(stateData.SAMLFlowID)
+	if err != nil {
+		return nil, err
+	}
+
+	qSAMLFlow, err := s.q.GetSAMLFlowByID(ctx, samlFlowID)
+	if err != nil {
+		return nil, err
+	}
+
+	if qSAMLFlow.SamlConnectionID != samlConnID {
+		return nil, fmt.Errorf("saml flow id does not match saml connection id")
+	}
+
 	return &AuthGetInitDataResponse{
 		RequestID:      stateData.SAMLFlowID,
 		IDPRedirectURL: *res.IdpRedirectUrl,
@@ -205,12 +219,12 @@ func (s *Store) AuthUpsertReceiveAssertionData(ctx context.Context, req *AuthUps
 			return nil, err
 		}
 
-		qSAMLConn, err := q.GetSAMLFlowByID(ctx, samlFlowID)
+		qSAMLFlow, err := q.GetSAMLFlowByID(ctx, samlFlowID)
 		if err != nil {
 			return nil, err
 		}
 
-		if qSAMLConn.SamlConnectionID != samlConnID {
+		if qSAMLFlow.SamlConnectionID != samlConnID {
 			return nil, fmt.Errorf("saml flow id does not match saml connection id")
 		}
 	}

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -200,6 +200,22 @@ func (s *Store) AuthUpsertReceiveAssertionData(ctx context.Context, req *AuthUps
 		return nil, err
 	}
 
+	if req.SAMLFlowID != "" {
+		samlFlowID, err := idformat.SAMLFlow.Parse(req.SAMLFlowID)
+		if err != nil {
+			return nil, err
+		}
+
+		qSAMLConn, err := q.GetSAMLFlowByID(ctx, samlFlowID)
+		if err != nil {
+			return nil, err
+		}
+
+		if qSAMLConn.SamlConnectionID != samlConnID {
+			return nil, fmt.Errorf("saml flow id does not match saml connection id")
+		}
+	}
+
 	var samlFlowID uuid.UUID
 	if req.SAMLFlowID != "" {
 		samlFlowID, err = idformat.SAMLFlow.Parse(req.SAMLFlowID)

--- a/internal/store/saml.go
+++ b/internal/store/saml.go
@@ -89,7 +89,6 @@ func (s *Store) GetSAMLRedirectURL(ctx context.Context, req *ssoreadyv1.GetSAMLR
 	redirectURLQuery := url.Values{}
 	redirectURLQuery.Set("state", s.statesigner.Encode(statesign.Data{
 		SAMLFlowID: idformat.SAMLFlow.Format(samlFlowID),
-		State:      req.State,
 	}))
 
 	redirectURL, err := url.Parse(authURL)


### PR DESCRIPTION
This PR simplifies how the `state` query parameter (used in the SAML `/init` endpoint) is encoded, and discontinues use of `RelayState` in SAML AuthnRequest entirely.

The `state` parameter to the `/init` endpoint serves only to keep track of the SAML flow that was created from a user's GetRedirectURL call. Initially, that parameter was also used to keep track of the user's provided `state` and then forwarded along as a SAML RelayState. However, when we later kept track of user-provided `state` directly on SAML flows (to let SSOReady users internally debug their `state`, even for failed SAML flows), it wasn't necessary to keep track of user-provided `state` using query params / RelayState.

This PR takes advantage of this simplification. `statesign` now only keeps track of a `SAMLFlowID`, and then we introduce a few checks to make sure you can't replay a SAML Flow across SAML connections.