### PR TITLE
Require SAML flows to be unique by SAML <Assertion> ID

### DIFF
--- a/cmd/migrate/migrations/000050_saml_flow_assertion_id.up.sql
+++ b/cmd/migrate/migrations/000050_saml_flow_assertion_id.up.sql
@@ -1,0 +1,2 @@
+alter table saml_flows add column assertion_id varchar;
+alter table saml_flows add unique (saml_connection_id, assertion_id);

--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -261,6 +261,7 @@ func (s *Service) samlAcs(w http.ResponseWriter, r *http.Request) {
 
 	createSAMLLoginRes, err := s.Store.AuthUpsertReceiveAssertionData(ctx, &store.AuthUpsertSAMLLoginEventRequest{
 		SAMLConnectionID:                     samlConnID,
+		SAMLAssertionID:                      &validateRes.AssertionID,
 		SAMLFlowID:                           validateRes.RequestID,
 		Email:                                email,
 		SubjectIDPAttributes:                 validateRes.SubjectAttributes,

--- a/internal/saml/samltypes/response.go
+++ b/internal/saml/samltypes/response.go
@@ -9,6 +9,7 @@ type Response struct {
 	XMLName   xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:protocol Response"`
 	Assertion struct {
 		XMLName   xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion Assertion"`
+		ID        string   `xml:"ID,attr"`
 		Signature struct {
 			XMLName    xml.Name `xml:"http://www.w3.org/2000/09/xmldsig# Signature"`
 			SignedInfo struct {

--- a/internal/saml/validate.go
+++ b/internal/saml/validate.go
@@ -31,6 +31,7 @@ type ValidateProblems struct {
 
 type ValidateResponse struct {
 	RequestID         string
+	AssertionID       string
 	Assertion         string
 	SubjectID         string
 	SubjectAttributes map[string]string
@@ -58,6 +59,7 @@ func Validate(req *ValidateRequest) (*ValidateResponse, *ValidateProblems, error
 
 	res := ValidateResponse{
 		RequestID:         samlRes.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.InResponseTo,
+		AssertionID:       samlRes.Assertion.ID,
 		Assertion:         string(data),
 		SubjectID:         samlRes.Assertion.Subject.NameID.Value,
 		SubjectAttributes: attrs,

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -184,6 +184,7 @@ func (s *Store) AuthCheckAssertionAlreadyProcessed(ctx context.Context, samlFlow
 
 type AuthUpsertSAMLLoginEventRequest struct {
 	SAMLConnectionID                     string
+	SAMLAssertionID                      *string
 	SAMLFlowID                           string
 	Email                                string
 	SubjectIDPAttributes                 map[string]string
@@ -271,6 +272,7 @@ func (s *Store) AuthUpsertReceiveAssertionData(ctx context.Context, req *AuthUps
 
 	qSAMLFlow, err := q.UpsertSAMLFlowReceiveAssertion(ctx, queries.UpsertSAMLFlowReceiveAssertionParams{
 		ID:                                   samlFlowID,
+		AssertionID:                          req.SAMLAssertionID,
 		SamlConnectionID:                     samlConnID,
 		AccessCodeSha256:                     accessCodeSHA,
 		ExpireTime:                           time.Now().Add(time.Hour),

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -276,6 +276,7 @@ type SamlFlow struct {
 	ErrorBadX509Certificate                       []byte
 	ErrorSamlConnectionNotConfigured              bool
 	ErrorEnvironmentOauthRedirectUriNotConfigured bool
+	AssertionID                                   *string
 }
 
 type SamlOauthClient struct {

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -282,7 +282,7 @@ func (q *Queries) AppListSCIMRequests(ctx context.Context, arg AppListSCIMReques
 }
 
 const authCheckAssertionAlreadyProcessed = `-- name: AuthCheckAssertionAlreadyProcessed :one
-select exists(select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured from saml_flows where id = $1 and access_code_sha256 is not null)
+select exists(select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id from saml_flows where id = $1 and access_code_sha256 is not null)
 `
 
 func (q *Queries) AuthCheckAssertionAlreadyProcessed(ctx context.Context, id uuid.UUID) (bool, error) {
@@ -465,7 +465,7 @@ func (q *Queries) AuthGetSAMLConnectionDomains(ctx context.Context, id uuid.UUID
 }
 
 const authGetSAMLFlow = `-- name: AuthGetSAMLFlow :one
-select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 from saml_flows
 where id = $1
 `
@@ -505,6 +505,7 @@ func (q *Queries) AuthGetSAMLFlow(ctx context.Context, id uuid.UUID) (SamlFlow, 
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
@@ -1387,7 +1388,7 @@ insert into saml_flows (id, saml_connection_id, expire_time, state, create_time,
                         auth_redirect_url, get_redirect_time, status, error_saml_connection_not_configured,
                         error_environment_oauth_redirect_uri_not_configured)
 values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 `
 
 type CreateSAMLFlowGetRedirectParams struct {
@@ -1451,6 +1452,7 @@ func (q *Queries) CreateSAMLFlowGetRedirect(ctx context.Context, arg CreateSAMLF
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
@@ -2055,7 +2057,7 @@ func (q *Queries) GetSAMLConnectionByID(ctx context.Context, id uuid.UUID) (Saml
 }
 
 const getSAMLFlow = `-- name: GetSAMLFlow :one
-select saml_flows.id, saml_flows.saml_connection_id, saml_flows.access_code, saml_flows.state, saml_flows.create_time, saml_flows.expire_time, saml_flows.email, saml_flows.subject_idp_attributes, saml_flows.update_time, saml_flows.auth_redirect_url, saml_flows.get_redirect_time, saml_flows.initiate_request, saml_flows.initiate_time, saml_flows.assertion, saml_flows.app_redirect_url, saml_flows.receive_assertion_time, saml_flows.redeem_time, saml_flows.redeem_response, saml_flows.error_bad_issuer, saml_flows.error_bad_audience, saml_flows.error_bad_subject_id, saml_flows.error_email_outside_organization_domains, saml_flows.status, saml_flows.error_unsigned_assertion, saml_flows.access_code_sha256, saml_flows.is_oauth, saml_flows.error_bad_signature_algorithm, saml_flows.error_bad_digest_algorithm, saml_flows.error_bad_x509_certificate, saml_flows.error_saml_connection_not_configured, saml_flows.error_environment_oauth_redirect_uri_not_configured
+select saml_flows.id, saml_flows.saml_connection_id, saml_flows.access_code, saml_flows.state, saml_flows.create_time, saml_flows.expire_time, saml_flows.email, saml_flows.subject_idp_attributes, saml_flows.update_time, saml_flows.auth_redirect_url, saml_flows.get_redirect_time, saml_flows.initiate_request, saml_flows.initiate_time, saml_flows.assertion, saml_flows.app_redirect_url, saml_flows.receive_assertion_time, saml_flows.redeem_time, saml_flows.redeem_response, saml_flows.error_bad_issuer, saml_flows.error_bad_audience, saml_flows.error_bad_subject_id, saml_flows.error_email_outside_organization_domains, saml_flows.status, saml_flows.error_unsigned_assertion, saml_flows.access_code_sha256, saml_flows.is_oauth, saml_flows.error_bad_signature_algorithm, saml_flows.error_bad_digest_algorithm, saml_flows.error_bad_x509_certificate, saml_flows.error_saml_connection_not_configured, saml_flows.error_environment_oauth_redirect_uri_not_configured, saml_flows.assertion_id
 from saml_flows
          join saml_connections on saml_flows.saml_connection_id = saml_connections.id
          join organizations on saml_connections.organization_id = organizations.id
@@ -2104,12 +2106,13 @@ func (q *Queries) GetSAMLFlow(ctx context.Context, arg GetSAMLFlowParams) (SamlF
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
 
 const getSAMLFlowByID = `-- name: GetSAMLFlowByID :one
-select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 from saml_flows
 where id = $1
 `
@@ -2149,6 +2152,7 @@ func (q *Queries) GetSAMLFlowByID(ctx context.Context, id uuid.UUID) (SamlFlow, 
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
@@ -2557,7 +2561,7 @@ func (q *Queries) ListSAMLConnections(ctx context.Context, arg ListSAMLConnectio
 }
 
 const listSAMLFlowsFirstPage = `-- name: ListSAMLFlowsFirstPage :many
-select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 from saml_flows
 where saml_connection_id = $1
 order by (create_time, id) desc
@@ -2610,6 +2614,7 @@ func (q *Queries) ListSAMLFlowsFirstPage(ctx context.Context, arg ListSAMLFlowsF
 			&i.ErrorBadX509Certificate,
 			&i.ErrorSamlConnectionNotConfigured,
 			&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+			&i.AssertionID,
 		); err != nil {
 			return nil, err
 		}
@@ -2622,7 +2627,7 @@ func (q *Queries) ListSAMLFlowsFirstPage(ctx context.Context, arg ListSAMLFlowsF
 }
 
 const listSAMLFlowsNextPage = `-- name: ListSAMLFlowsNextPage :many
-select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+select id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 from saml_flows
 where saml_connection_id = $1
   and (create_time, id) <= ($3, $4::uuid)
@@ -2683,6 +2688,7 @@ func (q *Queries) ListSAMLFlowsNextPage(ctx context.Context, arg ListSAMLFlowsNe
 			&i.ErrorBadX509Certificate,
 			&i.ErrorSamlConnectionNotConfigured,
 			&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+			&i.AssertionID,
 		); err != nil {
 			return nil, err
 		}
@@ -3410,7 +3416,7 @@ set update_time        = $1,
     status             = $4,
     access_code_sha256 = null
 where id = $5
-returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 `
 
 type UpdateSAMLFlowRedeemParams struct {
@@ -3462,6 +3468,7 @@ func (q *Queries) UpdateSAMLFlowRedeem(ctx context.Context, arg UpdateSAMLFlowRe
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
@@ -3471,7 +3478,7 @@ update saml_flows
 set email                  = $1,
     subject_idp_attributes = $2
 where id = $3
-returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 `
 
 type UpdateSAMLFlowSubjectDataParams struct {
@@ -3515,6 +3522,7 @@ func (q *Queries) UpdateSAMLFlowSubjectData(ctx context.Context, arg UpdateSAMLF
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
@@ -3577,7 +3585,7 @@ on conflict (id) do update set update_time      = excluded.update_time,
                                initiate_request = excluded.initiate_request,
                                initiate_time    = excluded.initiate_time,
                                status           = excluded.status
-returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 `
 
 type UpsertSAMLFlowInitiateParams struct {
@@ -3639,19 +3647,20 @@ func (q *Queries) UpsertSAMLFlowInitiate(ctx context.Context, arg UpsertSAMLFlow
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }
 
 const upsertSAMLFlowReceiveAssertion = `-- name: UpsertSAMLFlowReceiveAssertion :one
-insert into saml_flows (id, saml_connection_id, access_code_sha256, expire_time, state, create_time, update_time,
-                        assertion, receive_assertion_time, error_saml_connection_not_configured,
-                        error_unsigned_assertion, error_bad_issuer,
-                        error_bad_audience, error_bad_signature_algorithm, error_bad_digest_algorithm,
-                        error_bad_x509_certificate, error_bad_subject_id, error_email_outside_organization_domains,
-                        status)
-values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
-on conflict (id) do update set access_code_sha256                       = excluded.access_code_sha256,
+insert into saml_flows (id, saml_connection_id, assertion_id, access_code_sha256, expire_time, state, create_time,
+                        update_time, assertion, receive_assertion_time, error_saml_connection_not_configured,
+                        error_unsigned_assertion, error_bad_issuer, error_bad_audience, error_bad_signature_algorithm,
+                        error_bad_digest_algorithm, error_bad_x509_certificate, error_bad_subject_id,
+                        error_email_outside_organization_domains, status)
+values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+on conflict (id) do update set assertion_id                             = excluded.assertion_id,
+                               access_code_sha256                       = excluded.access_code_sha256,
                                update_time                              = excluded.update_time,
                                assertion                                = excluded.assertion,
                                receive_assertion_time                   = excluded.receive_assertion_time,
@@ -3665,12 +3674,13 @@ on conflict (id) do update set access_code_sha256                       = exclud
                                error_bad_subject_id                     = excluded.error_bad_subject_id,
                                error_email_outside_organization_domains = excluded.error_email_outside_organization_domains,
                                status                                   = excluded.status
-returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured
+returning id, saml_connection_id, access_code, state, create_time, expire_time, email, subject_idp_attributes, update_time, auth_redirect_url, get_redirect_time, initiate_request, initiate_time, assertion, app_redirect_url, receive_assertion_time, redeem_time, redeem_response, error_bad_issuer, error_bad_audience, error_bad_subject_id, error_email_outside_organization_domains, status, error_unsigned_assertion, access_code_sha256, is_oauth, error_bad_signature_algorithm, error_bad_digest_algorithm, error_bad_x509_certificate, error_saml_connection_not_configured, error_environment_oauth_redirect_uri_not_configured, assertion_id
 `
 
 type UpsertSAMLFlowReceiveAssertionParams struct {
 	ID                                   uuid.UUID
 	SamlConnectionID                     uuid.UUID
+	AssertionID                          *string
 	AccessCodeSha256                     []byte
 	ExpireTime                           time.Time
 	State                                string
@@ -3694,6 +3704,7 @@ func (q *Queries) UpsertSAMLFlowReceiveAssertion(ctx context.Context, arg Upsert
 	row := q.db.QueryRow(ctx, upsertSAMLFlowReceiveAssertion,
 		arg.ID,
 		arg.SamlConnectionID,
+		arg.AssertionID,
 		arg.AccessCodeSha256,
 		arg.ExpireTime,
 		arg.State,
@@ -3745,6 +3756,7 @@ func (q *Queries) UpsertSAMLFlowReceiveAssertion(ctx context.Context, arg Upsert
 		&i.ErrorBadX509Certificate,
 		&i.ErrorSamlConnectionNotConfigured,
 		&i.ErrorEnvironmentOauthRedirectUriNotConfigured,
+		&i.AssertionID,
 	)
 	return i, err
 }

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -82,14 +82,14 @@ on conflict (id) do update set update_time      = excluded.update_time,
 returning *;
 
 -- name: UpsertSAMLFlowReceiveAssertion :one
-insert into saml_flows (id, saml_connection_id, access_code_sha256, expire_time, state, create_time, update_time,
-                        assertion, receive_assertion_time, error_saml_connection_not_configured,
-                        error_unsigned_assertion, error_bad_issuer,
-                        error_bad_audience, error_bad_signature_algorithm, error_bad_digest_algorithm,
-                        error_bad_x509_certificate, error_bad_subject_id, error_email_outside_organization_domains,
-                        status)
-values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
-on conflict (id) do update set access_code_sha256                       = excluded.access_code_sha256,
+insert into saml_flows (id, saml_connection_id, assertion_id, access_code_sha256, expire_time, state, create_time,
+                        update_time, assertion, receive_assertion_time, error_saml_connection_not_configured,
+                        error_unsigned_assertion, error_bad_issuer, error_bad_audience, error_bad_signature_algorithm,
+                        error_bad_digest_algorithm, error_bad_x509_certificate, error_bad_subject_id,
+                        error_email_outside_organization_domains, status)
+values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+on conflict (id) do update set assertion_id                             = excluded.assertion_id,
+                               access_code_sha256                       = excluded.access_code_sha256,
                                update_time                              = excluded.update_time,
                                assertion                                = excluded.assertion,
                                receive_assertion_time                   = excluded.receive_assertion_time,

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -274,7 +274,8 @@ CREATE TABLE public.saml_flows (
     error_bad_digest_algorithm character varying,
     error_bad_x509_certificate bytea,
     error_saml_connection_not_configured boolean DEFAULT false NOT NULL,
-    error_environment_oauth_redirect_uri_not_configured boolean DEFAULT false NOT NULL
+    error_environment_oauth_redirect_uri_not_configured boolean DEFAULT false NOT NULL,
+    assertion_id character varying
 );
 
 
@@ -567,6 +568,14 @@ ALTER TABLE ONLY public.saml_flows
 
 ALTER TABLE ONLY public.saml_flows
     ADD CONSTRAINT saml_flows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: saml_flows saml_flows_saml_connection_id_assertion_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.saml_flows
+    ADD CONSTRAINT saml_flows_saml_connection_id_assertion_id_key UNIQUE (saml_connection_id, assertion_id);
 
 
 --


### PR DESCRIPTION
This PR requires that SAML flows have a unique SAML assertion ID. This defends against replay attacks from IDP-initiated SAML flows.

This uniqueness constraint is implemented at the SAML connection + assertion ID level. It's not clear to me whether this is any less correct than implementing this constraint without the scoping on SAML connection. I opt to do the compound constraint to follow the principle that constraints are never implemented across tenants, unless they're on SSOReady-controlled data.

For context, the SAML specification stipulates:

> Any party that assigns an identifier MUST ensure that there is negligible probability that that party or any other party will accidentally assign the same identifier to a different data object.

This language controls the specified behavior of a SAML `<Assertion>` element's `ID`.