### PR TITLE
Make dependency on S3 optional, for easier self-hosting of admin

### DIFF
--- a/admin/bin/prepare-config-json
+++ b/admin/bin/prepare-config-json
@@ -47,7 +47,7 @@ for (const [k, v] of Object.entries(process.env)) {
 
 for (const k of wantParams) {
   if (!(k in config)) {
-    console.error("missing required config var", `CONFIG_${k}`)
+    console.error("missing required config var", `ADMIN_${k}`)
     process.exit(1)
   }
 }

--- a/admin/bin/serve-public
+++ b/admin/bin/serve-public
@@ -17,5 +17,5 @@ const host = process.env.ADMIN_SERVE_HOST || "0.0.0.0"
 const port = parseInt(process.env.ADMIN_SERVE_PORT || "8083")
 
 app.listen(port, host, () => {
-    console.log(`serving ssoready app on ${host}:${port}`)
+    console.log(`serving ssoready admin on ${host}:${port}`)
 })

--- a/cmd/migrate/migrations/000051_environments_admin_logo_configured.up.sql
+++ b/cmd/migrate/migrations/000051_environments_admin_logo_configured.up.sql
@@ -1,0 +1,2 @@
+alter table environments
+    add column admin_logo_configured boolean not null default false;

--- a/internal/apiservice/admin.go
+++ b/internal/apiservice/admin.go
@@ -85,6 +85,10 @@ func (s *Service) AppUpdateAdminSettingsLogo(ctx context.Context, req *connect.R
 		return nil, fmt.Errorf("s3: %w", err)
 	}
 
+	if err := s.Store.AppUpdateEnvironmentAdminLogoConfigured(ctx, req.Msg.EnvironmentId, true); err != nil {
+		return nil, err
+	}
+
 	return connect.NewResponse(&ssoreadyv1.AppUpdateAdminSettingsLogoResponse{
 		UploadUrl: presignRequest.URL,
 	}), nil

--- a/internal/apiservice/admin.go
+++ b/internal/apiservice/admin.go
@@ -23,13 +23,16 @@ func (s *Service) AppGetAdminSettings(ctx context.Context, req *connect.Request[
 		return nil, fmt.Errorf("store: %w", err)
 	}
 
-	adminLogoURL, err := s.adminLogoURL(ctx, req.Msg.EnvironmentId)
-	if err != nil {
-		return nil, fmt.Errorf("admin logo url: %w", err)
+	var adminLogoURL string
+	if res.AdminLogoConfigured {
+		adminLogoURL, err = s.adminLogoURL(ctx, req.Msg.EnvironmentId)
+		if err != nil {
+			return nil, fmt.Errorf("admin logo url: %w", err)
+		}
 	}
 
-	res.AdminLogoUrl = adminLogoURL
-	return connect.NewResponse(res), nil
+	res.AppGetAdminSettingsResponse.AdminLogoUrl = adminLogoURL
+	return connect.NewResponse(res.AppGetAdminSettingsResponse), nil
 }
 
 // note well: adminLogoURL does no authz checks
@@ -111,9 +114,12 @@ func (s *Service) AdminWhoami(ctx context.Context, req *connect.Request[ssoready
 		return nil, fmt.Errorf("store: %w", err)
 	}
 
-	adminLogoURL, err := s.adminLogoURL(ctx, whoamiRes.EnvironmentID)
-	if err != nil {
-		return nil, fmt.Errorf("admin logo url: %w", err)
+	var adminLogoURL string
+	if whoamiRes.AdminLogoConfigured {
+		adminLogoURL, err = s.adminLogoURL(ctx, whoamiRes.EnvironmentID)
+		if err != nil {
+			return nil, fmt.Errorf("admin logo url: %w", err)
+		}
 	}
 
 	return connect.NewResponse(&ssoreadyv1.AdminWhoamiResponse{

--- a/internal/store/admin.go
+++ b/internal/store/admin.go
@@ -19,7 +19,12 @@ import (
 	"github.com/ssoready/ssoready/internal/store/queries"
 )
 
-func (s *Store) AppGetAdminSettings(ctx context.Context, req *ssoreadyv1.AppGetAdminSettingsRequest) (*ssoreadyv1.AppGetAdminSettingsResponse, error) {
+type GetAdminSettingsResponse struct {
+	AdminLogoConfigured         bool
+	AppGetAdminSettingsResponse *ssoreadyv1.AppGetAdminSettingsResponse
+}
+
+func (s *Store) AppGetAdminSettings(ctx context.Context, req *ssoreadyv1.AppGetAdminSettingsRequest) (*GetAdminSettingsResponse, error) {
 	envID, err := idformat.Environment.Parse(req.EnvironmentId)
 	if err != nil {
 		return nil, fmt.Errorf("parse environment id: %w", err)
@@ -33,10 +38,13 @@ func (s *Store) AppGetAdminSettings(ctx context.Context, req *ssoreadyv1.AppGetA
 		return nil, fmt.Errorf("get environment: %w", err)
 	}
 
-	return &ssoreadyv1.AppGetAdminSettingsResponse{
-		AdminApplicationName: derefOrEmpty(qEnv.AdminApplicationName),
-		AdminReturnUrl:       derefOrEmpty(qEnv.AdminReturnUrl),
-		AdminLogoUrl:         "", // set by apiservice, requires s3 api call
+	return &GetAdminSettingsResponse{
+		AppGetAdminSettingsResponse: &ssoreadyv1.AppGetAdminSettingsResponse{
+			AdminApplicationName: derefOrEmpty(qEnv.AdminApplicationName),
+			AdminReturnUrl:       derefOrEmpty(qEnv.AdminReturnUrl),
+			AdminLogoUrl:         "", // set by apiservice, requires s3 api call
+		},
+		AdminLogoConfigured: qEnv.AdminLogoConfigured,
 	}, nil
 }
 
@@ -221,6 +229,7 @@ type AdminWhoamiResponse struct {
 	AdminApplicationName string
 	AdminReturnURL       string
 	EnvironmentID        string
+	AdminLogoConfigured  bool
 }
 
 func (s *Store) AdminWhoami(ctx context.Context, req *ssoreadyv1.AdminWhoamiRequest) (*AdminWhoamiResponse, error) {
@@ -248,6 +257,7 @@ func (s *Store) AdminWhoami(ctx context.Context, req *ssoreadyv1.AdminWhoamiRequ
 		AdminApplicationName: derefOrEmpty(qEnv.AdminApplicationName),
 		AdminReturnURL:       derefOrEmpty(qEnv.AdminReturnUrl),
 		EnvironmentID:        idformat.Environment.Format(qEnv.ID),
+		AdminLogoConfigured:  qEnv.AdminLogoConfigured,
 	}, nil
 }
 

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -211,6 +211,7 @@ type Environment struct {
 	AdminReturnUrl       *string
 	CustomAdminDomain    *string
 	AdminUrl             *string
+	AdminLogoConfigured  bool
 }
 
 type OnboardingState struct {

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -3126,6 +3126,38 @@ func (q *Queries) UpdateEnvironment(ctx context.Context, arg UpdateEnvironmentPa
 	return i, err
 }
 
+const updateEnvironmentAdminLogoConfigured = `-- name: UpdateEnvironmentAdminLogoConfigured :one
+update environments
+set admin_logo_configured = $1
+where id = $2
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
+`
+
+type UpdateEnvironmentAdminLogoConfiguredParams struct {
+	AdminLogoConfigured bool
+	ID                  uuid.UUID
+}
+
+func (q *Queries) UpdateEnvironmentAdminLogoConfigured(ctx context.Context, arg UpdateEnvironmentAdminLogoConfiguredParams) (Environment, error) {
+	row := q.db.QueryRow(ctx, updateEnvironmentAdminLogoConfigured, arg.AdminLogoConfigured, arg.ID)
+	var i Environment
+	err := row.Scan(
+		&i.ID,
+		&i.RedirectUrl,
+		&i.AppOrganizationID,
+		&i.DisplayName,
+		&i.AuthUrl,
+		&i.OauthRedirectUri,
+		&i.CustomAuthDomain,
+		&i.AdminApplicationName,
+		&i.AdminReturnUrl,
+		&i.CustomAdminDomain,
+		&i.AdminUrl,
+		&i.AdminLogoConfigured,
+	)
+	return i, err
+}
+
 const updateEnvironmentAdminSettings = `-- name: UpdateEnvironmentAdminSettings :one
 update environments
 set admin_application_name = $1,

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -1263,7 +1263,7 @@ func (q *Queries) CreateEmailVerificationChallenge(ctx context.Context, arg Crea
 const createEnvironment = `-- name: CreateEnvironment :one
 insert into environments (id, redirect_url, oauth_redirect_uri, app_organization_id, display_name, auth_url)
 values ($1, $2, $3, $4, $5, $6)
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type CreateEnvironmentParams struct {
@@ -1297,6 +1297,7 @@ func (q *Queries) CreateEnvironment(ctx context.Context, arg CreateEnvironmentPa
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -1765,7 +1766,7 @@ func (q *Queries) GetEmailVerificationChallengeBySecretToken(ctx context.Context
 }
 
 const getEnvironment = `-- name: GetEnvironment :one
-select id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+select id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 from environments
 where app_organization_id = $1
   and id = $2
@@ -1791,12 +1792,13 @@ func (q *Queries) GetEnvironment(ctx context.Context, arg GetEnvironmentParams) 
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
 
 const getEnvironmentByID = `-- name: GetEnvironmentByID :one
-select id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+select id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 from environments
 where id = $1
 `
@@ -1816,6 +1818,7 @@ func (q *Queries) GetEnvironmentByID(ctx context.Context, id uuid.UUID) (Environ
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -2409,7 +2412,7 @@ func (q *Queries) ListAppUsers(ctx context.Context, appOrganizationID uuid.UUID)
 }
 
 const listEnvironments = `-- name: ListEnvironments :many
-select id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+select id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 from environments
 where app_organization_id = $1
   and id >= $2
@@ -2444,6 +2447,7 @@ func (q *Queries) ListEnvironments(ctx context.Context, arg ListEnvironmentsPara
 			&i.AdminReturnUrl,
 			&i.CustomAdminDomain,
 			&i.AdminUrl,
+			&i.AdminLogoConfigured,
 		); err != nil {
 			return nil, err
 		}
@@ -3085,7 +3089,7 @@ set display_name       = $1,
     auth_url           = $3,
     oauth_redirect_uri = $4
 where id = $5
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type UpdateEnvironmentParams struct {
@@ -3117,6 +3121,7 @@ func (q *Queries) UpdateEnvironment(ctx context.Context, arg UpdateEnvironmentPa
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -3126,7 +3131,7 @@ update environments
 set admin_application_name = $1,
     admin_return_url       = $2
 where id = $3
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type UpdateEnvironmentAdminSettingsParams struct {
@@ -3150,6 +3155,7 @@ func (q *Queries) UpdateEnvironmentAdminSettings(ctx context.Context, arg Update
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -3158,7 +3164,7 @@ const updateEnvironmentAdminURL = `-- name: UpdateEnvironmentAdminURL :one
 update environments
 set admin_url = $1
 where id = $2
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type UpdateEnvironmentAdminURLParams struct {
@@ -3181,6 +3187,7 @@ func (q *Queries) UpdateEnvironmentAdminURL(ctx context.Context, arg UpdateEnvir
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -3189,7 +3196,7 @@ const updateEnvironmentAuthURL = `-- name: UpdateEnvironmentAuthURL :one
 update environments
 set auth_url = $1
 where id = $2
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type UpdateEnvironmentAuthURLParams struct {
@@ -3212,6 +3219,7 @@ func (q *Queries) UpdateEnvironmentAuthURL(ctx context.Context, arg UpdateEnviro
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -3220,7 +3228,7 @@ const updateEnvironmentCustomAdminDomain = `-- name: UpdateEnvironmentCustomAdmi
 update environments
 set custom_admin_domain = $1
 where id = $2
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type UpdateEnvironmentCustomAdminDomainParams struct {
@@ -3243,6 +3251,7 @@ func (q *Queries) UpdateEnvironmentCustomAdminDomain(ctx context.Context, arg Up
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }
@@ -3251,7 +3260,7 @@ const updateEnvironmentCustomAuthDomain = `-- name: UpdateEnvironmentCustomAuthD
 update environments
 set custom_auth_domain = $1
 where id = $2
-returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url
+returning id, redirect_url, app_organization_id, display_name, auth_url, oauth_redirect_uri, custom_auth_domain, admin_application_name, admin_return_url, custom_admin_domain, admin_url, admin_logo_configured
 `
 
 type UpdateEnvironmentCustomAuthDomainParams struct {
@@ -3274,6 +3283,7 @@ func (q *Queries) UpdateEnvironmentCustomAuthDomain(ctx context.Context, arg Upd
 		&i.AdminReturnUrl,
 		&i.CustomAdminDomain,
 		&i.AdminUrl,
+		&i.AdminLogoConfigured,
 	)
 	return i, err
 }

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -498,6 +498,12 @@ set admin_application_name = $1,
 where id = $3
 returning *;
 
+-- name: UpdateEnvironmentAdminLogoConfigured :one
+update environments
+set admin_logo_configured = $1
+where id = $2
+returning *;
+
 -- name: CreateAdminAccessToken :one
 insert into admin_access_tokens (id, organization_id, one_time_token_sha256, create_time, expire_time, can_manage_saml,
                                  can_manage_scim)

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -174,7 +174,8 @@ CREATE TABLE public.environments (
     admin_application_name character varying,
     admin_return_url character varying,
     custom_admin_domain character varying,
-    admin_url character varying
+    admin_url character varying,
+    admin_logo_configured boolean DEFAULT false NOT NULL
 );
 
 


### PR DESCRIPTION
Right now, admin has a dependency on S3 in order to power custom logos. This PR softens that dependency; S3 is only a dependency if you want to use custom logos.

One known caveat in this implementation is that requesting an upload URL marks the environment has having a logo defined. But the upload, which the app immediately uses after requesting the URL, may fail. This isn't a problem for this PR, because 1) we still have handling for GetObject failing, and 2) for self-hosted instances that don't have s3 configured correctly, the attempt to generate a presigned URL will fail beforehand.

Additionally, this PR clarifies/corrects some logs related to running admin and looking for ADMIN_ env vars.