### PR TITLE
Add correlation_id for all logs and panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.7 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/cyrusaf/ctxlog v1.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/aws/smithy-go v1.20.4/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyrusaf/ctxlog v1.3.2 h1:leWXPIB/YzPCe7+gRmBqz96EgBwH6fqaOtQ1mcMM1WM=
+github.com/cyrusaf/ctxlog v1.3.2/go.mod h1:uYxERwb2tWRzkPzJUObIRzmhS/yd1QnL+3R9F3IkoXI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/slogcorrelation/slogcorrelation.go
+++ b/internal/slogcorrelation/slogcorrelation.go
@@ -1,0 +1,27 @@
+package slogcorrelation
+
+import (
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/cyrusaf/ctxlog"
+	"github.com/google/uuid"
+)
+
+func NewHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = ctxlog.WithAttrs(ctx, slog.String("correlation_id", uuid.NewString()))
+		r = r.WithContext(ctx)
+
+		defer func() {
+			if err := recover(); err != nil {
+				slog.ErrorContext(ctx, "panic", "err", err, "stack", string(debug.Stack()))
+				panic(err)
+			}
+		}()
+
+		h.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
This PR adds a correlation_id, scoped to an HTTP request, for all panics and slog-based logs.