### PR TITLE
scim: entra: support PATCHes to userName

### DIFF
--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -986,6 +986,33 @@ func (q *Queries) AuthUpdateSCIMUser(ctx context.Context, arg AuthUpdateSCIMUser
 	return i, err
 }
 
+const authUpdateSCIMUserEmail = `-- name: AuthUpdateSCIMUserEmail :one
+update scim_users
+set email = $1
+where scim_directory_id = $2
+  and id = $3
+returning id, scim_directory_id, email, deleted, attributes
+`
+
+type AuthUpdateSCIMUserEmailParams struct {
+	Email           string
+	ScimDirectoryID uuid.UUID
+	ID              uuid.UUID
+}
+
+func (q *Queries) AuthUpdateSCIMUserEmail(ctx context.Context, arg AuthUpdateSCIMUserEmailParams) (ScimUser, error) {
+	row := q.db.QueryRow(ctx, authUpdateSCIMUserEmail, arg.Email, arg.ScimDirectoryID, arg.ID)
+	var i ScimUser
+	err := row.Scan(
+		&i.ID,
+		&i.ScimDirectoryID,
+		&i.Email,
+		&i.Deleted,
+		&i.Attributes,
+	)
+	return i, err
+}
+
 const authUpsertSCIMUser = `-- name: AuthUpsertSCIMUser :one
 insert into scim_users (id, scim_directory_id, email, deleted, attributes)
 values ($1, $2, $3, $4, $5)

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -614,6 +614,13 @@ where scim_directory_id = $3
   and id = $4
 returning *;
 
+-- name: AuthUpdateSCIMUserEmail :one
+update scim_users
+set email = $1
+where scim_directory_id = $2
+  and id = $3
+returning *;
+
 -- name: AuthMarkSCIMUserDeleted :one
 update scim_users
 set deleted = true


### PR DESCRIPTION
This PR adds support for Entra's pattern for updating SCIM user `userName` values. It does so by carrying out a SCIM PATCH request to the user's `userName` attribute.

This PR introduces a new code path that has to take care to make sure to enforce user email domain membership.