### PR TITLE
authservice: scim: do not treat user 404 as error condition

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -164,7 +164,7 @@ func (s *Service) scimGetUser(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		if errors.Is(err, store.ErrSCIMUserNotFound) {
 			w.WriteHeader(http.StatusNotFound)
-			return err
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
This PR fixes a regression introduced in #132. When a user is not found, this PR has scimGetUser return `nil` after setting the response status to 404. Previously, it re-raised the error, leading the scim request logs middleware to treat the error as fatal.

Screenshot of the logs middleware being happy even as a user 404s:

![screenshot-2024-10-16-11-47-25](https://github.com/user-attachments/assets/f1ca352f-4f59-4587-a4d8-609c824bc247)
