### PR TITLE
Update prettyuuid to 285da46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/rs/cors v1.11.0
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/ssoready/conf v0.0.0-20240508183332-dbc356674c9e
-	github.com/ssoready/prettyuuid v0.0.0-20240423172315-97d04d6848dd
+	github.com/ssoready/prettyuuid v0.0.0-20241023163822-285da46017b3
 	github.com/stretchr/testify v1.9.0
 	github.com/ucarion/cli v0.2.0
 	golang.org/x/crypto v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/ssoready/conf v0.0.0-20240508183332-dbc356674c9e h1:HGv623enEZ6punSNt
 github.com/ssoready/conf v0.0.0-20240508183332-dbc356674c9e/go.mod h1:oOONPDIKXlG7GzuEei63WLmLAgmeyNTxQgo44sybMrQ=
 github.com/ssoready/prettyuuid v0.0.0-20240423172315-97d04d6848dd h1:biiF7e4C6B210/GFoNXkEDTiYHJwpzEXWKsIJf/ZDa8=
 github.com/ssoready/prettyuuid v0.0.0-20240423172315-97d04d6848dd/go.mod h1:NFiy4pMH935y/R0gYcTEGy7yhhe2obny113T2YR3AlM=
+github.com/ssoready/prettyuuid v0.0.0-20241023163822-285da46017b3 h1:nyUOgLJuQcc7OEHpnk6RxDbK6R4rIKjFZH4aYxi1LzU=
+github.com/ssoready/prettyuuid v0.0.0-20241023163822-285da46017b3/go.mod h1:NFiy4pMH935y/R0gYcTEGy7yhhe2obny113T2YR3AlM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
This PR updates the dependency on prettyuuid to the latest commit, which provides better error messages.

See: https://github.com/ssoready/prettyuuid/pull/1