### PR TITLE
scim: Support '-' in email addresses

### DIFF
--- a/internal/emailaddr/emailaddr.go
+++ b/internal/emailaddr/emailaddr.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var pat = regexp.MustCompile(`^[a-zA-Z0-9_.-\\+]+@([a-zA-Z0-9_.-]+)$`)
+var pat = regexp.MustCompile(`^[a-zA-Z0-9_.\-\\+]+@([a-zA-Z0-9_.-]+)$`)
 
 func Parse(s string) (string, error) {
 	match := pat.FindStringSubmatch(s)

--- a/internal/emailaddr/emailaddr_test.go
+++ b/internal/emailaddr/emailaddr_test.go
@@ -27,6 +27,14 @@ func TestParse(t *testing.T) {
 			in:  "jdoe@EXAMPLE.com",
 			out: "example.com",
 		},
+		{
+			in:  "john-doe@example.com",
+			out: "example.com",
+		},
+		{
+			in:  "john-doe.foo@example.com",
+			out: "example.com",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
This fixes a bug in SCIM preventing email addresses that contain `-` from being created in SCIM directories.

The `-` character in regex is a reserved character if inside `[]`. A simple escape `\` fixes the logic to what I believe was the original intent.