### PR TITLE
scim: fix user deletion on email PATCHing

### DIFF
--- a/internal/store/auth_scim.go
+++ b/internal/store/auth_scim.go
@@ -310,10 +310,6 @@ func (s *Store) AuthUpdateSCIMUserEmail(ctx context.Context, req *AuthUpdateSCIM
 		return fmt.Errorf("update scim user email: %w", err)
 	}
 
-	if _, err := q.AuthMarkSCIMUserDeleted(ctx, scimUserID); err != nil {
-		return fmt.Errorf("mark scim user deleted: %w", err)
-	}
-
 	if err := commit(); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}


### PR DESCRIPTION
This PR fixes a bug wherein users are marked as deleted on their email being updated.

There was never a good reason we did so; this is a straightforward bug, plain and simple. We overlooked this in QA.

Closes #164.