### PR TITLE
Add scimpatch and use SCIM data model as IR in user scim operations

### DIFF
--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -1,0 +1,125 @@
+package scimpatch
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Operation struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value"`
+}
+
+func Patch(ops []Operation, obj *map[string]any) error {
+	for _, op := range ops {
+		if err := applyOp(op, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyOp(op Operation, obj *map[string]any) error {
+	opReplace := op.Op == "replace" || op.Op == "Replace"
+	opAdd := op.Op == "add" || op.Op == "Add"
+
+	if !opReplace && !opAdd {
+		return fmt.Errorf("unsupported SCIM PATCH operation: %q", op.Op)
+	}
+
+	segments := splitPath(op.Path)
+
+	if len(segments) == 0 {
+		if opReplace {
+			val, ok := op.Value.(map[string]any)
+			if !ok {
+				return fmt.Errorf("top-level 'replace' operation must have an object value")
+			}
+			*obj = val
+			return nil
+		}
+
+		if opAdd {
+			return fmt.Errorf("unsupported 'add' operation on top-level object")
+		}
+	}
+
+	for _, segment := range segments[:len(segments)-1] {
+		subV, ok := (*obj)[segment].(map[string]any)
+		if !ok {
+			return fmt.Errorf("invalid path: %q", op.Path)
+		}
+
+		obj = &subV
+	}
+
+	k := segments[len(segments)-1]
+	if opReplace {
+		(*obj)[k] = op.Value
+		return nil
+	}
+	if opAdd {
+		if err := applyAdd(*obj, k, op.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyAdd(obj map[string]any, k string, v any) error {
+	if _, ok := obj[k]; !ok {
+		obj[k] = v
+		return nil
+	}
+
+	switch objVal := obj[k].(type) {
+	case map[string]any:
+		v, ok := v.(map[string]any)
+		if !ok {
+			return fmt.Errorf("'add' operation pointing at object must be object-valued")
+		}
+
+		for k := range v {
+			objVal[k] = v[k]
+		}
+		return nil
+	case []any:
+		v, ok := v.([]any)
+		if !ok {
+			return fmt.Errorf("'add' operation pointing at array must be array-valued")
+		}
+
+		obj[k] = append(objVal, v...)
+		return nil
+	default:
+		obj[k] = v
+		return nil
+	}
+}
+
+var enterpriseUserPrefix = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+
+// splitPath splits an op's path into its segments
+//
+// splitPath has special-case behavior as a concession to Entra's non-conformant
+// behavior; they do PATCHes with paths like:
+//
+//	urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager
+//
+// Entra intends this to mean the "manager" property under "urn:...:User", but
+// the spec indicates this should mean the "urn:...:2" > "0:User:manager"
+// property. The selective behavior around ":" and "." can't be made to make
+// sense beyond just a straightforward special-casing.
+func splitPath(path string) []string {
+	if path == "" {
+		return nil
+	}
+	if path == enterpriseUserPrefix {
+		return []string{enterpriseUserPrefix}
+	}
+	if strings.HasPrefix(path, enterpriseUserPrefix+":") {
+		return []string{enterpriseUserPrefix, strings.TrimPrefix(path, enterpriseUserPrefix+":")}
+	}
+	return strings.Split(path, ".")
+}

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -1,0 +1,132 @@
+package scimpatch_test
+
+import (
+	"testing"
+
+	"github.com/ssoready/ssoready/internal/scimpatch"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatch(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   map[string]any
+		ops  []scimpatch.Operation
+		out  map[string]any
+	}{
+		{
+			name: "replace entire value",
+			in:   map[string]any{"foo": "xxx"},
+			ops:  []scimpatch.Operation{{Op: "replace", Path: "", Value: map[string]any{"bar": "yyy"}}},
+			out:  map[string]any{"bar": "yyy"},
+		},
+		{
+			name: "replace top-level prop",
+			in:   map[string]any{"foo": "xxx"},
+			ops:  []scimpatch.Operation{{Op: "replace", Path: "foo", Value: "yyy"}},
+			out:  map[string]any{"foo": "yyy"},
+		},
+		{
+			name: "replace nested prop",
+			in:   map[string]any{"foo": map[string]any{"bar": "xxx"}},
+			ops:  []scimpatch.Operation{{Op: "replace", Path: "foo.bar", Value: "yyy"}},
+			out:  map[string]any{"foo": map[string]any{"bar": "yyy"}},
+		},
+		{
+			name: "replace map prop",
+			in:   map[string]any{"foo": map[string]any{"bar": "xxx"}},
+			ops:  []scimpatch.Operation{{Op: "replace", Path: "foo", Value: map[string]any{"bar": "yyy"}}},
+			out:  map[string]any{"foo": map[string]any{"bar": "yyy"}},
+		},
+		{
+			name: "replace scalar with map",
+			in:   map[string]any{"foo": map[string]any{"bar": "xxx"}},
+			ops:  []scimpatch.Operation{{Op: "replace", Path: "foo.bar", Value: map[string]any{"baz": "yyy"}}},
+			out:  map[string]any{"foo": map[string]any{"bar": map[string]any{"baz": "yyy"}}},
+		},
+		{
+			name: "add to slice",
+			in:   map[string]any{"foo": []any{"xxx"}},
+			ops:  []scimpatch.Operation{{Op: "add", Path: "foo", Value: []any{"yyy"}}},
+			out:  map[string]any{"foo": []any{"xxx", "yyy"}},
+		},
+		{
+			name: "add multiple to slice", // this is inferred from spec; unclear if used in the wild
+			in:   map[string]any{"foo": []any{"xxx"}},
+			ops:  []scimpatch.Operation{{Op: "add", Path: "foo", Value: []any{"yyy", "zzz"}}},
+			out:  map[string]any{"foo": []any{"xxx", "yyy", "zzz"}},
+		},
+		{
+			name: "add to empty property",
+			in:   map[string]any{},
+			ops:  []scimpatch.Operation{{Op: "add", Path: "foo", Value: "yyy"}},
+			out:  map[string]any{"foo": "yyy"},
+		},
+		{
+			name: "add to sub-object",
+			in:   map[string]any{"foo": map[string]any{"bar": "xxx"}},
+			ops:  []scimpatch.Operation{{Op: "add", Path: "foo", Value: map[string]any{"baz": "yyy"}}},
+			out:  map[string]any{"foo": map[string]any{"bar": "xxx", "baz": "yyy"}},
+		},
+
+		{
+			name: "uppercase Replace op",
+			in:   map[string]any{"foo": "xxx"},
+			ops:  []scimpatch.Operation{{Op: "Replace", Path: "", Value: map[string]any{"bar": "yyy"}}},
+			out:  map[string]any{"bar": "yyy"},
+		},
+		{
+			name: "uppercase Add op",
+			in:   map[string]any{"foo": []any{"xxx"}},
+			ops:  []scimpatch.Operation{{Op: "Add", Path: "foo", Value: []any{"yyy"}}},
+			out:  map[string]any{"foo": []any{"xxx", "yyy"}},
+		},
+
+		{
+			name: "special-case for entra patches on enterprise user",
+			in: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"foo": "xxx",
+				},
+			},
+			ops: []scimpatch.Operation{
+				{
+					Op:    "Add",
+					Path:  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:bar",
+					Value: "yyy",
+				},
+			},
+			out: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"foo": "xxx",
+					"bar": "yyy",
+				},
+			},
+		},
+		{
+			// inferred behavior; not seen in wild -- case where there's no sub-":" in the path
+			name: "special-case for entra patches on enterprise user",
+			in:   map[string]any{},
+			ops: []scimpatch.Operation{
+				{
+					Op:    "Add",
+					Path:  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+					Value: map[string]any{"foo": "xxx"},
+				},
+			},
+			out: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"foo": "xxx",
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := scimpatch.Patch(tt.ops, &tt.in)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.out, tt.in)
+		})
+	}
+}

--- a/internal/store/auth_scim.go
+++ b/internal/store/auth_scim.go
@@ -183,6 +183,33 @@ func (s *Store) AuthGetSCIMUser(ctx context.Context, req *AuthGetSCIMUserRequest
 	return parseSCIMUser(qSCIMUser), nil
 }
 
+type AuthGetSCIMUserIncludeDeletedRequest struct {
+	SCIMDirectoryID string
+	SCIMUserID      string
+}
+
+func (s *Store) AuthGetSCIMUserIncludeDeleted(ctx context.Context, req *AuthGetSCIMUserIncludeDeletedRequest) (*ssoreadyv1.SCIMUser, error) {
+	scimDirID, err := idformat.SCIMDirectory.Parse(req.SCIMDirectoryID)
+	if err != nil {
+		return nil, fmt.Errorf("parse scim directory id: %w", err)
+	}
+
+	scimUserID, err := idformat.SCIMUser.Parse(req.SCIMUserID)
+	if err != nil {
+		return nil, fmt.Errorf("parse scim user id: %w", err)
+	}
+
+	qSCIMUser, err := s.q.AuthGetSCIMUserIncludeDeleted(ctx, queries.AuthGetSCIMUserIncludeDeletedParams{
+		ScimDirectoryID: scimDirID,
+		ID:              scimUserID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get scim user include deleted: %w", err)
+	}
+
+	return parseSCIMUser(qSCIMUser), nil
+}
+
 type AuthCreateSCIMUserRequest struct {
 	SCIMUser *ssoreadyv1.SCIMUser
 }


### PR DESCRIPTION
This PR makes two changes to how SCIM user operations work:

1. Introduce scimpatch, which implements SCIM patch semantics, but with exceptions to the spec made to accommodate Entra's noncompliant behavior.
2. The SCIM data model now acts as an intermediate representation (IR). SCIM operations operate on the SCIM data model representation of users, which gets converted to/from the store layer's representation.

The main difficulty here is in accommodating, in a way that makes users get details right by default, two big ways that Entra does not comply with the SCIM specification:

1. The `active` property is supposed to be a boolean, but Entra sets it as the JSON string `"True"` or `"False"` by default.
2. Entra makes up, in some but not all cases, its own syntax for paths to nested fields. In particular, it sends requests with this kind of path:


```
urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager
```

With the intention being that this manipulates `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` > `manager`. This is illegal on two levels: the `.` in `2.0` should be a field delimiter, and the `:` in `User:manager` is not a legal field delimiter. There's no good logic here, either -- `:` can't be considered a delimiter in general, because `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` is meant to be considered a single field.

There's no way to make Entra's logic make sense. Instead, this PR opts to simply special-case this syntax.