### PR TITLE
scim: add support for remove op on members with a value

### DIFF
--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -430,6 +430,25 @@ func (q *Queries) AuthCreateSCIMRequest(ctx context.Context, arg AuthCreateSCIMR
 	return i, err
 }
 
+const authDeleteSCIMUserGroupMembership = `-- name: AuthDeleteSCIMUserGroupMembership :exec
+delete
+from scim_user_group_memberships
+where scim_directory_id = $1
+  and scim_user_id = $2
+  and scim_group_id = $3
+`
+
+type AuthDeleteSCIMUserGroupMembershipParams struct {
+	ScimDirectoryID uuid.UUID
+	ScimUserID      uuid.UUID
+	ScimGroupID     uuid.UUID
+}
+
+func (q *Queries) AuthDeleteSCIMUserGroupMembership(ctx context.Context, arg AuthDeleteSCIMUserGroupMembershipParams) error {
+	_, err := q.db.Exec(ctx, authDeleteSCIMUserGroupMembership, arg.ScimDirectoryID, arg.ScimUserID, arg.ScimGroupID)
+	return err
+}
+
 const authGetInitData = `-- name: AuthGetInitData :one
 select idp_redirect_url, sp_entity_id
 from saml_connections

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -727,6 +727,13 @@ insert into scim_user_group_memberships (id, scim_directory_id, scim_user_id,
 values ($1, $2, $3, $4)
 on conflict (scim_user_id, scim_group_id) do nothing;
 
+-- name: AuthDeleteSCIMUserGroupMembership :exec
+delete
+from scim_user_group_memberships
+where scim_directory_id = $1
+  and scim_user_id = $2
+  and scim_group_id = $3;
+
 -- name: AuthCreateSCIMRequest :one
 insert into scim_requests (id, scim_directory_id, timestamp, http_request_url,
                            http_request_method,


### PR DESCRIPTION
This PR adds support for a nonstandard way Entra implements SCIM group/user disassociation: via a PATCH on the group with a `remove` (actually `Remove`) on `members` with a `value`. That `value` is an array with an element whose (inner) `value` is a SCIM user ID.

An example such request:

```
curl -H "Authorization: Bearer ssoready_scim_bearer_token_7ow5vxyzyrbvaege3lvjndp5l" http://localhost:8080/v1/scim/scim_directory_209i1hhe8vls7zrxwmnfvf8rh/Groups/scim_group_93j9z2miz4kgitaqmtycacb47 -X PATCH -d '{"operations": [{"op":"remove","path":"members","value":[{"value":"scim_user_767ja3jcmyly6w7oc0qzh0wnk"}]}]}'
```