### PR TITLE
ViewEnvironmentPage: validate external ID does not have leading/trailing whitespace

### DIFF
--- a/app/src/pages/ViewEnvironmentPage.tsx
+++ b/app/src/pages/ViewEnvironmentPage.tsx
@@ -396,7 +396,9 @@ function EditEnvironmentAlertDialog({
 
 const OrgFormSchema = z.object({
   displayName: z.string(),
-  externalId: z.string(),
+  externalId: z.string().refine((value) => value.trim() === value, {
+    message: "External ID must not have leading or trailing whitespace.",
+  }),
   domains: z.array(z.string()).min(1, {
     message: "At least one domain is required.",
   }),


### PR DESCRIPTION
This PR validates that organizations created through the UI do not have leading/trailing whitespace. External ID is often created via copy-paste, so users have noted that whitespace-related problems are easy to have happen.

![screenshot-2024-10-28-15-31-43](https://github.com/user-attachments/assets/fbe3a2cc-7946-4ca4-8f4b-993deb870666)

I've confirmed that not setting an external ID at all continues to work.