### PR TITLE
authproxy, adminproxy: increase min_machines_running to 3

### DIFF
--- a/cmd/adminproxy/fly-prod.toml
+++ b/cmd/adminproxy/fly-prod.toml
@@ -16,7 +16,7 @@ primary_region = 'iad'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 3
   processes = ['app']
 
 [[vm]]

--- a/cmd/authproxy/fly-prod.toml
+++ b/cmd/authproxy/fly-prod.toml
@@ -11,7 +11,7 @@ primary_region = 'iad'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 3
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
This PR increases the minimum number of machines running for authproxy and adminproxy to 3.