### PR TITLE
auth: 400 on bad state param in saml init, and improve error message

### DIFF
--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -116,6 +116,12 @@ func (s *Service) samlInit(w http.ResponseWriter, r *http.Request) {
 		State:            state,
 	})
 	if err != nil {
+		var badState *store.AuthGetInitDataBadStateError
+		if errors.As(err, &badState) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		panic(err)
 	}
 

--- a/internal/statesign/statesign.go
+++ b/internal/statesign/statesign.go
@@ -22,6 +22,10 @@ func (signer *Signer) Encode(d Data) string {
 }
 
 func (signer *Signer) Decode(s string) (*Data, error) {
+	if s == "" {
+		return nil, fmt.Errorf("invalid empty param")
+	}
+
 	payloadBase64, digestBase64, ok := strings.Cut(s, ".")
 	if !ok {
 		return nil, fmt.Errorf("invalid signature: missing '.'")

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -30,6 +30,14 @@ type AuthGetInitDataResponse struct {
 	SPEntityID     string
 }
 
+type AuthGetInitDataBadStateError struct {
+	err error
+}
+
+func (e *AuthGetInitDataBadStateError) Error() string {
+	return fmt.Sprintf("bad state param: %s", e.err.Error())
+}
+
 func (s *Store) AuthGetInitData(ctx context.Context, req *AuthGetInitDataRequest) (*AuthGetInitDataResponse, error) {
 	samlConnID, err := idformat.SAMLConnection.Parse(req.SAMLConnectionID)
 	if err != nil {
@@ -43,7 +51,7 @@ func (s *Store) AuthGetInitData(ctx context.Context, req *AuthGetInitDataRequest
 
 	stateData, err := s.statesigner.Decode(req.State)
 	if err != nil {
-		return nil, err
+		return nil, &AuthGetInitDataBadStateError{err}
 	}
 
 	samlFlowID, err := idformat.SAMLFlow.Parse(stateData.SAMLFlowID)


### PR DESCRIPTION
This PR has auth return a 400, with a more helpful error message, when clients call the saml init endpoint with no state parameter.