### PR TITLE
api: make API_CLOUDFLARE_API_KEY optional

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -118,9 +118,13 @@ func main() {
 		analyticsClient = analytics.New(config.SegmentWriteKey)
 	}
 
-	cloudflareClient, err := cloudflare.NewWithAPIToken(config.CloudflareAPIKey)
-	if err != nil {
-		panic(err)
+	var cloudflareClient *cloudflare.API
+	if config.CloudflareAPIKey != "" {
+		client, err := cloudflare.NewWithAPIToken(config.CloudflareAPIKey)
+		if err != nil {
+			panic(err)
+		}
+		cloudflareClient = client
 	}
 
 	connectPath, connectHandler := ssoreadyv1connect.NewSSOReadyServiceHandler(


### PR DESCRIPTION
This PR makes `API_CLOUDFLARE_API_KEY` by instantiating the cloudflare client as nil by default.

Closes #203.