### PR TITLE
scim: patch users: do not allow removal of userName

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -363,6 +363,11 @@ func (s *Service) scimPatchUser(w http.ResponseWriter, r *http.Request) error {
 	// convert back to our representation
 	patchedSCIMUser := scimUserFromResource(scimDirectoryID, scimUserID, scimUserResource)
 
+	// do not allow patches to remove the user email address
+	if patchedSCIMUser.Email == "" {
+		patchedSCIMUser.Email = scimUser.Email
+	}
+
 	slog.InfoContext(ctx, "patched_user_fetch", "patched_scim_user_resource", scimUserResource, "patched_scim_user", patchedSCIMUser)
 
 	// validate email


### PR DESCRIPTION
This PR adds support for SCIM PATCH requests to a user which attempt to remove all properties using a top-level `replace` operation with a value of `{"active": false}`. We deliberately do not support having SCIM users without an email address; few customers are in a place to handle such a user. Currently, such requests fail because the resulting user has no email address, and so fails the email domain check.

To support this sort of deprovisioning strategy, this PR has the SCIM server opt to deactivate the user but keep their email address as-is.

After this PR, these updates work:

```
$ curl -H "authorization: Bearer ..." http://localhost:8080/v1/scim/.../Users/... -X PATCH -d '{"Operations":[{"op":"replace","value":{"active":false}}]}'
```