### PR TITLE
auth: fix misconfiguration error logging for oauth flows

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -104,7 +104,7 @@ func (s *Service) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 		if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeFailedPrecondition {
 			if connectErr.Message() == "environment OAuth redirect URI not configured, see: https://ssoready.com/docs/ssoready-concepts/saml-login-flows#environment-oauth-redirect-uri-not-configured" {
 				if _, err := s.Store.UpsertNotConfiguredSAMLFlow(ctx, &store.UpsertNotConfiguredSAMLFlowRequest{
-					SAMLConnectionID:                         samlConnID,
+					SAMLConnectionID:                         dataRes.SAMLConnectionID,
 					EnvironmentOAuthRedirectURINotConfigured: true,
 				}); err != nil {
 					panic(err)
@@ -116,7 +116,7 @@ func (s *Service) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 
 			if connectErr.Message() == "saml connection is not fully configured, see: https://ssoready.com/docs/ssoready-concepts/saml-flows#saml-connection-not-fully-configured" {
 				if _, err := s.Store.UpsertNotConfiguredSAMLFlow(ctx, &store.UpsertNotConfiguredSAMLFlowRequest{
-					SAMLConnectionID:            samlConnID,
+					SAMLConnectionID:            dataRes.SAMLConnectionID,
 					SAMLConnectionNotConfigured: true,
 				}); err != nil {
 					panic(err)


### PR DESCRIPTION
The logging we do on SAML flows when a saml connection is not properly configured for OAuth does not work when the OAuth flow is done using `?organization_id=...` or `?organization_external_id=...`. This PR fixes that.

Now this request produces the expected error:

```
$ http://localhost:8080/v1/oauth/authorize?client_id=saml_oauth_client_eg9guxp1ygtmb4bsptiujk80m&organization_id=org_8rqbf2kyvxh78mqzhjdpawoml

failed_precondition: environment OAuth redirect URI not configured, see: https://ssoready.com/docs/ssoready-concepts/saml-login-flows#environment-oauth-redirect-uri-not-configured
```

It also correctly produces a failed saml flow:

![screenshot-2024-12-03-11-38-10](https://github.com/user-attachments/assets/8ba717e5-e949-42ab-a56a-1afe3dce1d68)

The same works after configuring the redirect URI, but making the primary saml connection invalid:

```
$ curl http://localhost:8080/v1/oauth/authorize\?client_id\=saml_oauth_client_eg9guxp1ygtmb4bsptiujk80m\&organization_id\=org_8rqbf2kyvxh78mqzhjdpawoml
failed_precondition: saml connection is not fully configured, see: https://ssoready.com/docs/ssoready-concepts/saml-flows#saml-connection-not-fully-configured
```