### PR TITLE
auth: Improve error message on double-use of saml access code in SAML-over-OAuth

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -209,6 +209,11 @@ func (s *Service) oauthToken(w http.ResponseWriter, r *http.Request) {
 		SamlAccessCode: r.FormValue("code"),
 	})
 	if err != nil {
+		var samlAccessCodeNotFoundErr *store.SAMLAccessCodeNotFoundError
+		if errors.As(err, &samlAccessCodeNotFoundErr) {
+			http.Error(w, "saml access code not found, or already used", http.StatusNotFound)
+			return
+		}
 		panic(err)
 	}
 


### PR DESCRIPTION
This PR has us return a 404 with a clear message when double-using, or making up wholesale, a SAML access code.

```
$ curl [...]

< HTTP/1.1 404 Not Found
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 04 Dec 2024 16:25:12 GMT
< Content-Length: 44
< 
saml access code not found, or already used
```