### PR TITLE
store: saml: return connect.NewError on failing to find saml access code

### DIFF
--- a/internal/store/saml.go
+++ b/internal/store/saml.go
@@ -178,7 +178,7 @@ func (s *Store) RedeemSAMLAccessCode(ctx context.Context, req *ssoreadyv1.Redeem
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &SAMLAccessCodeNotFoundError{err}
+			return nil, connect.NewError(connect.CodeInvalidArgument, &SAMLAccessCodeNotFoundError{err})
 		}
 		return nil, fmt.Errorf("get saml access code data: %w", err)
 	}

--- a/internal/store/saml.go
+++ b/internal/store/saml.go
@@ -134,12 +134,10 @@ func (s *Store) GetSAMLRedirectURL(ctx context.Context, req *ssoreadyv1.GetSAMLR
 	return &ssoreadyv1.GetSAMLRedirectURLResponse{RedirectUrl: redirect}, nil
 }
 
-type SAMLAccessCodeNotFoundError struct {
-	Err error
-}
+type SAMLAccessCodeNotFoundError struct{}
 
 func (e *SAMLAccessCodeNotFoundError) Error() string {
-	return fmt.Sprintf("saml access code not found: %s", e.Err.Error())
+	return fmt.Sprintf("saml access code not found, or already used")
 }
 
 func (s *Store) RedeemSAMLAccessCode(ctx context.Context, req *ssoreadyv1.RedeemSAMLAccessCodeRequest) (*ssoreadyv1.RedeemSAMLAccessCodeResponse, error) {
@@ -178,7 +176,7 @@ func (s *Store) RedeemSAMLAccessCode(ctx context.Context, req *ssoreadyv1.Redeem
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, connect.NewError(connect.CodeInvalidArgument, &SAMLAccessCodeNotFoundError{err})
+			return nil, connect.NewError(connect.CodeNotFound, &SAMLAccessCodeNotFoundError{})
 		}
 		return nil, fmt.Errorf("get saml access code data: %w", err)
 	}


### PR DESCRIPTION
This PR has us return a 404 on failing to find a SAML access code. We already do so for the SAML-over-OAuth flow; this PR updates the main API to have the same behavior.

```
curl -H "content-type: application/json" -H "Authorization: Bearer ssoready_sk_3zbppu18tdzkeke7j4zrggr11" http://localhost:8081/v1/saml/redeem -d '{ "samlAccessCode": "saml_access_code_2pmfho5igl297d65yhnh69gkw" }' -v
*   Trying [::1]:8081...
* connect to ::1 port 8081 failed: Connection refused
*   Trying 127.0.0.1:8081...
* Connected to localhost (127.0.0.1) port 8081
> POST /v1/saml/redeem HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/8.4.0
> Accept: */*
> content-type: application/json
> Authorization: Bearer ssoready_sk_3zbppu18tdzkeke7j4zrggr11
> Content-Length: 66
> 
< HTTP/1.1 404 Not Found
< Accept-Encoding: gzip
< Content-Type: application/json
< Date: Wed, 11 Dec 2024 18:04:50 GMT
< Content-Length: 79
< 
* Connection #0 to host localhost left intact
{"code":5,"message":"saml access code not found, or already used","details":[]}%                                                                                     
```