### PR TITLE
auth: 400 instead of panics on invalid tokens passed to oauth userinfo

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -265,12 +265,14 @@ func (s *Service) oauthUserinfo(w http.ResponseWriter, r *http.Request) {
 
 	idToken, err := jwt.ParseSigned(accessToken, []jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
-		panic(err)
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
 	}
 
 	var claims idTokenClaims
 	if err := idToken.Claims(&s.OAuthIDTokenPrivateKey.PublicKey, &claims); err != nil {
-		panic(err)
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
 	}
 
 	userinfo := struct {


### PR DESCRIPTION
This PR has auth return a 400, instead of panicking, on malformed or invalid tokens passed to the userinfo endpoint.