### PR TITLE
auth: return 400 on repeated IDP-initiated SAML flows

### DIFF
--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -284,6 +284,11 @@ func (s *Service) samlAcs(w http.ResponseWriter, r *http.Request) {
 		ErrorEmailOutsideOrganizationDomains: domainMismatchEmail,
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrDuplicateAssertionID) {
+			http.Error(w, "assertion previously processed", http.StatusBadRequest)
+			return
+		}
+
 		panic(err)
 	}
 


### PR DESCRIPTION
This PR has auth return a 400 on replayed/repeated IDP-initated SAML flows. We already have this logic in place for SP-initiated flows, where we can catch it earlier in the flow.

When an assertion turns out to violate the `(saml_connection_id, assertion_id)` uniqueness constraint, then store now returns a specific error for that case.