### PR TITLE
auth: return 400 on saml flow ID / saml connection ID mismatch

### DIFF
--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -289,6 +289,11 @@ func (s *Service) samlAcs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if errors.Is(err, store.ErrSAMLConnectionIDMismatch) {
+			http.Error(w, "assertion not intended for this SAML connection", http.StatusBadRequest)
+			return
+		}
+
 		panic(err)
 	}
 

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -227,6 +227,7 @@ type AuthUpsertSAMLLoginEventResponse struct {
 }
 
 var ErrDuplicateAssertionID = errors.New("an assertion with this ID has already been processed")
+var ErrSAMLConnectionIDMismatch = errors.New("saml connection id does not match saml flow id")
 
 func (s *Store) AuthUpsertReceiveAssertionData(ctx context.Context, req *AuthUpsertSAMLLoginEventRequest) (*AuthUpsertSAMLLoginEventResponse, error) {
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -325,7 +326,7 @@ func (s *Store) AuthUpsertReceiveAssertionData(ctx context.Context, req *AuthUps
 	}
 
 	if qSAMLFlow.SamlConnectionID != samlConnID {
-		return nil, fmt.Errorf("saml flow does not belong to given saml connection")
+		return nil, ErrSAMLConnectionIDMismatch
 	}
 
 	attrs, err := json.Marshal(req.SubjectIDPAttributes)


### PR DESCRIPTION
This PR has auth return a 400 when a SAML assertion meant for one SAML connection is sent to another SAML connection. Previously, we preemptively panicked in this situation.