### PR TITLE
fix: format SCIM error responses as JSON for proper logging

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -356,7 +356,17 @@ func (s *Service) scimPatchUser(w http.ResponseWriter, r *http.Request) error {
 
 	// apply patches
 	if err := scimpatch.Patch(patch.Operations, &scimUserResource); err != nil {
-		http.Error(w, fmt.Sprintf("unsupported PATCH operation: %s", err.Error()), http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/scim+json")
+		w.WriteHeader(http.StatusBadRequest)
+		errorResponse := map[string]interface{}{
+			"schemas":  []string{"urn:ietf:params:scim:api:messages:2.0:Error"},
+			"status":   "400",
+			"scimType": "invalidPath",
+			"detail":   fmt.Sprintf("Unsupported PATCH operation: %s", err.Error()),
+		}
+		if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
+			panic(fmt.Errorf("encode error response: %w", err))
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Currently error responses in SCIM endpoints are returned as plain text,
which causes them to be filtered out from the request logs in the SSOReady UI.
This makes debugging harder as error details are not visible in the app.

This commit:
- Updates error responses to use SCIM-compliant JSON format
- Sets correct Content-Type header for SCIM responses
- Ensures error responses are properly captured in logs
- Improves error handling for Azure AD/Entra ID integration

Resolves #230
Related to #228
