### PR TITLE
auth: scim: allow filtering groups by displayName

### DIFF
--- a/internal/store/auth_scim.go
+++ b/internal/store/auth_scim.go
@@ -386,8 +386,9 @@ func (s *Store) AuthDeleteSCIMUser(ctx context.Context, req *AuthDeleteSCIMUserR
 }
 
 type AuthListSCIMGroupsRequest struct {
-	SCIMDirectoryID string
-	StartIndex      int
+	SCIMDirectoryID   string
+	StartIndex        int
+	FilterDisplayName string
 }
 
 type AuthListSCIMGroupsResponse struct {
@@ -412,13 +413,30 @@ func (s *Store) AuthListSCIMGroups(ctx context.Context, req *AuthListSCIMGroupsR
 		return nil, fmt.Errorf("count scim groups: %w", err)
 	}
 
-	qSCIMGroups, err := q.AuthListSCIMGroups(ctx, queries.AuthListSCIMGroupsParams{
-		ScimDirectoryID: scimDirID,
-		Offset:          int32(req.StartIndex),
-		Limit:           10,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list scim groups: %w", err)
+	var qSCIMGroups []queries.ScimGroup
+	if req.FilterDisplayName == "" {
+		qGroups, err := q.AuthListSCIMGroups(ctx, queries.AuthListSCIMGroupsParams{
+			ScimDirectoryID: scimDirID,
+			Offset:          int32(req.StartIndex),
+			Limit:           10,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list scim groups: %w", err)
+		}
+
+		qSCIMGroups = qGroups
+	} else {
+		qGroups, err := q.AuthListSCIMGroupsByDisplayName(ctx, queries.AuthListSCIMGroupsByDisplayNameParams{
+			ScimDirectoryID: scimDirID,
+			DisplayName:     req.FilterDisplayName,
+			Offset:          int32(req.StartIndex),
+			Limit:           10,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list scim groups by display name: %w", err)
+		}
+
+		qSCIMGroups = qGroups
 	}
 
 	var scimGroups []*ssoreadyv1.SCIMGroup

--- a/internal/store/auth_scim.go
+++ b/internal/store/auth_scim.go
@@ -408,9 +408,24 @@ func (s *Store) AuthListSCIMGroups(ctx context.Context, req *AuthListSCIMGroupsR
 	}
 	defer rollback()
 
-	count, err := q.AuthCountSCIMGroups(ctx, scimDirID)
-	if err != nil {
-		return nil, fmt.Errorf("count scim groups: %w", err)
+	var count int64
+	if req.FilterDisplayName == "" {
+		c, err := q.AuthCountSCIMGroups(ctx, scimDirID)
+		if err != nil {
+			return nil, fmt.Errorf("count scim groups: %w", err)
+		}
+
+		count = c
+	} else {
+		c, err := q.AuthCountSCIMGroupsByDisplayName(ctx, queries.AuthCountSCIMGroupsByDisplayNameParams{
+			ScimDirectoryID: scimDirID,
+			DisplayName:     req.FilterDisplayName,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("count scim groups: %w", err)
+		}
+
+		count = c
 	}
 
 	var qSCIMGroups []queries.ScimGroup

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -326,6 +326,26 @@ func (q *Queries) AuthCountSCIMGroups(ctx context.Context, scimDirectoryID uuid.
 	return count, err
 }
 
+const authCountSCIMGroupsByDisplayName = `-- name: AuthCountSCIMGroupsByDisplayName :one
+select count(*)
+from scim_groups
+where scim_directory_id = $1
+  and deleted = false
+  and display_name = $2
+`
+
+type AuthCountSCIMGroupsByDisplayNameParams struct {
+	ScimDirectoryID uuid.UUID
+	DisplayName     string
+}
+
+func (q *Queries) AuthCountSCIMGroupsByDisplayName(ctx context.Context, arg AuthCountSCIMGroupsByDisplayNameParams) (int64, error) {
+	row := q.db.QueryRow(ctx, authCountSCIMGroupsByDisplayName, arg.ScimDirectoryID, arg.DisplayName)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const authCountSCIMUsers = `-- name: AuthCountSCIMUsers :one
 select count(*)
 from scim_users

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -707,6 +707,13 @@ where scim_directory_id = $1
 order by id
 offset $2 limit $3;
 
+-- name: AuthCountSCIMGroupsByDisplayName :one
+select count(*)
+from scim_groups
+where scim_directory_id = $1
+  and deleted = false
+  and display_name = $2;
+
 -- name: AuthListSCIMGroupsByDisplayName :many
 select *
 from scim_groups

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -707,6 +707,15 @@ where scim_directory_id = $1
 order by id
 offset $2 limit $3;
 
+-- name: AuthListSCIMGroupsByDisplayName :many
+select *
+from scim_groups
+where scim_directory_id = $1
+  and deleted = false
+  and display_name = $2
+order by id
+offset $3 limit $4;
+
 -- name: AuthGetSCIMGroup :one
 select *
 from scim_groups

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -3,11 +3,12 @@
 --
 
 -- Dumped from database version 15.3 (Debian 15.3-1.pgdg120+1)
--- Dumped by pg_dump version 15.8 (Homebrew)
+-- Dumped by pg_dump version 17.0 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);


### PR DESCRIPTION
This PR allows SCIM clients to filter groups by displayName. This behavior is required by Entra under certain configurations.

```console
$ curl -s -H "Authorization: Bearer ssoready_scim_bearer_token_6jyc3dqv52vo7q8f5m0sp5ucc" http://localhost:8080/v1/scim/scim_directory_3e03jy1zzisw5fdiljwx8xgy5/Groups | jq                          
{
  "totalResults": 2,
  "itemsPerPage": 2,
  "startIndex": 0,
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:Group"
  ],
  "resources": [
    {
      "displayName": "asdf",
      "id": "scim_group_9nt3cb1j92gqlibjic72533xg"
    },
    {
      "displayName": "foobar",
      "id": "scim_group_aa33x9kzeejuhp6jfxzi0tz53"
    }
  ]
}

$ curl -s -H "Authorization: Bearer ssoready_scim_bearer_token_6jyc3dqv52vo7q8f5m0sp5ucc" 'http://localhost:8080/v1/scim/scim_directory_3e03jy1zzisw5fdiljwx8xgy5/Groups?filter=displayName+eq+"asdf"' | jq
{
  "totalResults": 1,
  "itemsPerPage": 1,
  "startIndex": 0,
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:Group"
  ],
  "resources": [
    {
      "displayName": "asdf",
      "id": "scim_group_9nt3cb1j92gqlibjic72533xg"
    }
  ]
}

```