### PR TITLE
feat: Add Entra-compatible SCIM manager reference conversion with tests

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -811,6 +811,18 @@ func scimUserToResource(scimUser *ssoreadyv1.SCIMUser) map[string]any {
 		r["active"] = false
 	}
 
+	// convert simple manager id reference to complex manager reference for Entra compatibility
+	if r["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"] != nil {
+		enterpriseUser := r["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].(map[string]any)
+		if enterpriseUser["manager"] != nil {
+			if managerID, ok := enterpriseUser["manager"].(string); ok {
+				enterpriseUser["manager"] = map[string]any{
+					"value": managerID,
+				}
+			}
+		}
+	}
+
 	return r
 }
 

--- a/internal/authservice/scim_test.go
+++ b/internal/authservice/scim_test.go
@@ -1,0 +1,105 @@
+package authservice
+
+import (
+	"testing"
+
+	ssoreadyv1 "github.com/ssoready/ssoready/internal/gen/ssoready/v1"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestSCIMUserToResource_ManagerReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *ssoreadyv1.SCIMUser
+		expected map[string]any
+	}{
+		{
+			name: "simple manager ID is converted to complex reference",
+			input: &ssoreadyv1.SCIMUser{
+				Id:    "user123",
+				Email: "test@example.com",
+				Attributes: mustNewStruct(map[string]any{
+					"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+						"manager": "manager123",
+					},
+				}),
+			},
+			expected: map[string]any{
+				"id":       "user123",
+				"userName": "test@example.com",
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"manager": map[string]any{
+						"value": "manager123",
+					},
+				},
+			},
+		},
+		{
+			name: "already complex manager reference is preserved",
+			input: &ssoreadyv1.SCIMUser{
+				Id:    "user123",
+				Email: "test@example.com",
+				Attributes: mustNewStruct(map[string]any{
+					"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+						"manager": map[string]any{
+							"value": "manager123",
+						},
+					},
+				}),
+			},
+			expected: map[string]any{
+				"id":       "user123",
+				"userName": "test@example.com",
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"manager": map[string]any{
+						"value": "manager123",
+					},
+				},
+			},
+		},
+		{
+			name: "no manager reference remains unchanged",
+			input: &ssoreadyv1.SCIMUser{
+				Id:    "user123",
+				Email: "test@example.com",
+				Attributes: mustNewStruct(map[string]any{
+					"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{},
+				}),
+			},
+			expected: map[string]any{
+				"id":       "user123",
+				"userName": "test@example.com",
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{},
+			},
+		},
+		{
+			name: "no enterprise extension remains unchanged",
+			input: &ssoreadyv1.SCIMUser{
+				Id:         "user123",
+				Email:      "test@example.com",
+				Attributes: mustNewStruct(map[string]any{}),
+			},
+			expected: map[string]any{
+				"id":       "user123",
+				"userName": "test@example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scimUserToResource(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create structpb.Struct from map
+func mustNewStruct(m map[string]any) *structpb.Struct {
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		panic(err)
+	}
+	return s
+} 


### PR DESCRIPTION
This PR implements and tests the conversion of SCIM manager references to ensure compatibility with Microsoft Entra (Azure AD). The change converts simple manager ID references to complex references as required by Entra's SCIM implementation.

Implementation Changes:
- Added manager reference conversion in `scimUserToResource` function
- Converts simple manager ID format (`"manager": "manager123"`) to complex format (`"manager": {"value": "manager123"}`)
- Preserves existing complex references
- Maintains backward compatibility with other SCIM providers

Test Coverage:
Added new test file `internal/authservice/scim_test.go` with comprehensive test cases:
- ✅ Simple manager ID conversion to complex reference
- ✅ Complex manager reference preservation
- ✅ Empty manager reference handling
- ✅ Missing enterprise extension handling

This change ensures our SCIM implementation works correctly with Microsoft Entra while maintaining compatibility with other SCIM providers.