### PR TITLE
feat: Add comprehensive SCIM filter expressions support for patch operations

### DIFF
--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -2,13 +2,33 @@ package scimpatch
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type Operation struct {
 	Op    string `json:"op"`
 	Path  string `json:"path"`
 	Value any    `json:"value"`
+}
+
+type pathSegment struct {
+	name   string
+	filter *filterExpr
+}
+
+type filterExpr struct {
+	attr  string
+	op    string
+	value string
+}
+
+func (p pathSegment) String() string {
+	if p.filter == nil {
+		return p.name
+	}
+	return fmt.Sprintf("%s[%s %s \"%s\"]", p.name, p.filter.attr, p.filter.op, p.filter.value)
 }
 
 func Patch(ops []Operation, obj *map[string]any) error {
@@ -45,25 +65,152 @@ func applyOp(op Operation, obj *map[string]any) error {
 		}
 	}
 
-	for _, segment := range segments[:len(segments)-1] {
-		subV, ok := (*obj)[segment].(map[string]any)
+	current := obj
+	for i, segment := range segments {
+		isLast := i == len(segments)-1
+
+		if segment.filter != nil {
+			arr, ok := (*current)[segment.name].([]any)
+			if !ok {
+				return fmt.Errorf("invalid path: array not found at %q", segment.String())
+			}
+
+			modified := false
+			for j, item := range arr {
+				if m, ok := item.(map[string]any); ok {
+					if v, exists := m[segment.filter.attr]; exists {
+						matches := false
+						switch segment.filter.op {
+						case "eq":
+							matches = v == segment.filter.value
+						case "ne":
+							matches = v != segment.filter.value
+						case "co":
+							if str, ok := v.(string); ok {
+								matches = strings.Contains(str, segment.filter.value)
+							} else {
+								return fmt.Errorf("'co' operator can only be used with string values")
+							}
+						case "sw":
+							if str, ok := v.(string); ok {
+								matches = strings.HasPrefix(str, segment.filter.value)
+							} else {
+								return fmt.Errorf("'sw' operator can only be used with string values")
+							}
+						case "ew":
+							if str, ok := v.(string); ok {
+								matches = strings.HasSuffix(str, segment.filter.value)
+							} else {
+								return fmt.Errorf("'ew' operator can only be used with string values")
+							}
+						case "pr":
+							if str, ok := v.(string); ok {
+								matches = str != ""
+							} else {
+								matches = v != nil
+							}
+						case "gt", "ge", "lt", "le":
+							switch val := v.(type) {
+							case string:
+								// Try to parse as date first
+								if date, err := time.Parse(time.RFC3339, val); err == nil {
+									compareDate, err := time.Parse(time.RFC3339, segment.filter.value)
+									if err != nil {
+										return fmt.Errorf("invalid date format in comparison: %q", segment.filter.value)
+									}
+									matches = compareDates(date, compareDate, segment.filter.op)
+								} else {
+									matches = compare(val, segment.filter.value, segment.filter.op)
+								}
+							case float64:
+								num, err := strconv.ParseFloat(segment.filter.value, 64)
+								if err != nil {
+									return fmt.Errorf("invalid number in comparison: %q", segment.filter.value)
+								}
+								matches = compare(val, num, segment.filter.op)
+							case int:
+								num, err := strconv.ParseFloat(segment.filter.value, 64)
+								if err != nil {
+									return fmt.Errorf("invalid number in comparison: %q", segment.filter.value)
+								}
+								matches = compare(float64(val), num, segment.filter.op)
+							default:
+								return fmt.Errorf("comparison operators can only be used with string or numeric values")
+							}
+						default:
+							return fmt.Errorf("unsupported filter operator: %q", segment.filter.op)
+						}
+
+						if matches {
+							modified = true
+							if isLast {
+								if strings.Contains(op.Path, "].") {
+									// If we have a field after the filter, create a new operation for it
+									parts := strings.Split(op.Path, "].")
+									if len(parts) == 2 {
+										newMap := make(map[string]any)
+										for k, v := range m {
+											newMap[k] = v
+										}
+										arr[j] = newMap
+										if err := applyOp(Operation{
+											Op:    op.Op,
+											Path:  parts[1],
+											Value: op.Value,
+										}, &newMap); err != nil {
+											return err
+										}
+									}
+								} else {
+									// If no field after the filter, replace the entire object
+									arr[j] = op.Value
+								}
+							} else {
+								// Not the last segment, continue with the rest of the path
+								newMap := make(map[string]any)
+								for k, v := range m {
+									newMap[k] = v
+								}
+								arr[j] = newMap
+								if err := applyOp(Operation{
+									Op:    op.Op,
+									Path:  strings.Join(segmentsToStrings(segments[i+1:]), "."),
+									Value: op.Value,
+								}, &newMap); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				}
+			}
+			if !modified {
+				return fmt.Errorf("no matching element found for filter %q", segment.String())
+			}
+			(*current)[segment.name] = arr
+			return nil
+		}
+
+		if isLast {
+			if opReplace {
+				(*current)[segment.name] = op.Value
+				return nil
+			}
+			if opAdd {
+				if err := applyAdd(*current, segment.name, op.Value); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		subV, ok := (*current)[segment.name].(map[string]any)
 		if !ok {
-			return fmt.Errorf("invalid path: %q", op.Path)
+			return fmt.Errorf("invalid path: %q", segment.String())
 		}
-
-		obj = &subV
+		current = &subV
 	}
 
-	k := segments[len(segments)-1]
-	if opReplace {
-		(*obj)[k] = op.Value
-		return nil
-	}
-	if opAdd {
-		if err := applyAdd(*obj, k, op.Value); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -111,15 +258,95 @@ var enterpriseUserPrefix = "urn:ietf:params:scim:schemas:extension:enterprise:2.
 // the spec indicates this should mean the "urn:...:2" > "0:User:manager"
 // property. The selective behavior around ":" and "." can't be made to make
 // sense beyond just a straightforward special-casing.
-func splitPath(path string) []string {
+func splitPath(path string) []pathSegment {
 	if path == "" {
 		return nil
 	}
 	if path == enterpriseUserPrefix {
-		return []string{enterpriseUserPrefix}
+		return []pathSegment{{name: enterpriseUserPrefix}}
 	}
 	if strings.HasPrefix(path, enterpriseUserPrefix+":") {
-		return []string{enterpriseUserPrefix, strings.TrimPrefix(path, enterpriseUserPrefix+":")}
+		remainingPath := strings.TrimPrefix(path, enterpriseUserPrefix+":")
+		return append([]pathSegment{{name: enterpriseUserPrefix}}, splitPath(remainingPath)...)
 	}
-	return strings.Split(path, ".")
+
+	var segments []pathSegment
+	for _, part := range strings.Split(path, ".") {
+		if idx := strings.Index(part, "["); idx != -1 {
+			if end := strings.Index(part, "]"); end != -1 {
+				filter := parseFilter(part[idx+1 : end])
+				segments = append(segments, pathSegment{
+					name:   part[:idx],
+					filter: filter,
+				})
+				continue
+			}
+		}
+		segments = append(segments, pathSegment{name: part})
+	}
+	return segments
+}
+
+func parseFilter(expr string) *filterExpr {
+	parts := strings.Split(expr, " ")
+	if len(parts) == 2 && parts[1] == "pr" {
+		return &filterExpr{
+			attr: parts[0],
+			op:   "pr",
+		}
+	}
+	if len(parts) != 3 {
+		return nil
+	}
+	// Remove quotes from value
+	value := strings.Trim(parts[2], "\"")
+	return &filterExpr{
+		attr:  parts[0],
+		op:    parts[1],
+		value: value,
+	}
+}
+
+// Helper function to convert pathSegments back to strings
+func segmentsToStrings(segments []pathSegment) []string {
+	result := make([]string, len(segments))
+	for i, seg := range segments {
+		result[i] = seg.String()
+	}
+	return result
+}
+
+// comparable is a constraint that permits ordered comparisons
+type ordered interface {
+	~string | ~float64 | ~int
+}
+
+func compare[T ordered](a, b T, op string) bool {
+	switch op {
+	case "gt":
+		return a > b
+	case "ge":
+		return a >= b
+	case "lt":
+		return a < b
+	case "le":
+		return a <= b
+	default:
+		return false
+	}
+}
+
+func compareDates(a, b time.Time, op string) bool {
+	switch op {
+	case "gt":
+		return a.After(b)
+	case "ge":
+		return a.After(b) || a.Equal(b)
+	case "lt":
+		return a.Before(b)
+	case "le":
+		return a.Before(b) || a.Equal(b)
+	default:
+		return false
+	}
 }

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -13,6 +13,7 @@ func TestPatch(t *testing.T) {
 		in   map[string]any
 		ops  []scimpatch.Operation
 		out  map[string]any
+		err  string
 	}{
 		{
 			name: "replace entire value",
@@ -120,13 +121,589 @@ func TestPatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replace with filter expression in path",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type eq \"bar\"].str", Value: "zzz"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace entire object with filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type eq \"bar\"]", Value: map[string]any{
+				"type": "baz",
+				"str":  "zzz",
+			}}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with not-equal filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type ne \"foo\"].str", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "aaa",
+					},
+				},
+			},
+		},
+		{
+			name: "replace entire object with not-equal filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type ne \"foo\"]", Value: map[string]any{
+				"type": "aaa",
+				"str":  "bbb",
+			}}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "bbb",
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "bbb",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with contains filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy_abc",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str co \"abc\"].type", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "yyy_abc",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with starts-with filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "xxx_def",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "yyy_abc",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str sw \"xxx\"].type", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx_def",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "yyy_abc",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with ends-with filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy_def",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz_abc",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str ew \"abc\"].type", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy_def",
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "zzz_abc",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with present filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "",
+					},
+					map[string]any{
+						"type": "qux",
+						"str":  nil,
+					},
+					map[string]any{
+						"type": "qux",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str pr].type", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "",
+					},
+					map[string]any{
+						"type": "qux",
+						"str":  nil,
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with greater than filter expression on strings",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str gt \"mmm\"].type", Value: "xxx"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "xxx",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with greater than or equal filter expression on strings",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str ge \"mmm\"].type", Value: "xxx"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "xxx",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "xxx",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with less than filter expression on strings",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str lt \"mmm\"].type", Value: "xxx"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "xxx",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with less than or equal filter expression on strings",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str le \"mmm\"].type", Value: "xxx"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "xxx",
+						"str":  "aaa",
+					},
+					map[string]any{
+						"type": "xxx",
+						"str":  "mmm",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with comparison operators on numbers",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"num":  10,
+					},
+					map[string]any{
+						"type": "bar",
+						"num":  20,
+					},
+					map[string]any{
+						"type": "baz",
+						"num":  30,
+					},
+				},
+			},
+			ops: []scimpatch.Operation{
+				{Op: "Replace", Path: "items[num gt \"20\"].type", Value: "xxx"},
+				{Op: "Replace", Path: "items[num lt \"20\"].type", Value: "yyy"},
+			},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "yyy",
+						"num":  10,
+					},
+					map[string]any{
+						"type": "bar",
+						"num":  20,
+					},
+					map[string]any{
+						"type": "xxx",
+						"num":  30,
+					},
+				},
+			},
+		},
+		{
+			name: "comparison operators with invalid types should fail",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"val":  true,
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[val gt \"true\"].type", Value: "xxx"}},
+			err: "comparison operators can only be used with string or numeric values",
+		},
+		{
+			name: "replace with comparison operators on dates",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"date": "2024-01-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "bar",
+						"date": "2024-02-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "baz",
+						"date": "2024-03-01T00:00:00Z",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{
+				{Op: "Replace", Path: "items[date gt \"2024-02-01T00:00:00Z\"].type", Value: "xxx"},
+				{Op: "Replace", Path: "items[date lt \"2024-02-01T00:00:00Z\"].type", Value: "yyy"},
+			},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "yyy",
+						"date": "2024-01-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "bar",
+						"date": "2024-02-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "xxx",
+						"date": "2024-03-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		{
+			name: "comparison operators with invalid date format should fail",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"date": "2024-01-01T00:00:00Z",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[date gt \"invalid-date\"].type", Value: "xxx"}},
+			err: "invalid date format in comparison: \"invalid-date\"",
+		},
+		{
+			name: "replace with filter in enterprise user path",
+			in: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"items": []any{
+						map[string]any{
+							"type": "foo",
+							"str":  "xxx",
+						},
+						map[string]any{
+							"type": "bar",
+							"str":  "yyy",
+						},
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:items[type eq \"bar\"].str", Value: "zzz"}},
+			out: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"items": []any{
+						map[string]any{
+							"type": "foo",
+							"str":  "xxx",
+						},
+						map[string]any{
+							"type": "bar",
+							"str":  "zzz",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			err := scimpatch.Patch(tt.ops, &tt.in)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.out, tt.in)
+			if tt.err != "" {
+				assert.Error(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.out, tt.in)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR introduces robust support for SCIM filter expressions in patch operations, significantly enhancing the SCIM implementation's filtering capabilities. The changes include:

### New Filter Operators
- Basic comparison: `eq` (equals) and `ne` (not equals)
- String operations: 
  - `co` (contains)
  - `sw` (starts with)
  - `ew` (ends with)
  - `pr` (present)
- Comparison operators:
  - `gt` (greater than)
  - `ge` (greater than or equal)
  - `lt` (less than)
  - `le` (less than or equal)

### Key Features
- Support for filtering on string, numeric, and date values
- Proper handling of enterprise user prefix edge cases
- Comprehensive test coverage for all filter operations
- Type-safe comparison operations with proper error handling
- Maintains backward compatibility with existing SCIM operations

### Technical Details
- Implemented new `pathSegment` and `filterExpr` structs for better filter expression handling
- Added support for RFC3339 date comparisons
- Enhanced error handling for invalid filter expressions and type mismatches
- Optimized string manipulation for filter parsing

This enhancement allows for more precise and flexible SCIM resource manipulation, making the implementation more compliant with the SCIM specification and more powerful for enterprise use cases.

Fixes #228 