### PR TITLE
auth: Have userinfo return Firebase-friendly OIDC claims

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -276,9 +276,13 @@ func (s *Service) oauthUserinfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userinfo := struct {
-		Sub string `json:"sub"`
+		Sub           string `json:"sub"`
+		Email         string `json:"email"`
+		EmailVerified bool   `json:"email_verified"`
 	}{
-		Sub: claims.Subject,
+		Sub:           claims.Subject,
+		Email:         claims.Subject,
+		EmailVerified: true,
 	}
 
 	if err := json.NewEncoder(w).Encode(userinfo); err != nil {


### PR DESCRIPTION
This PR updates the SAML-over-OAuth userinfo endpoint to return `email` and `email_verified` claims that Firebase understands. This saves users from needing to manually copy this information themselves, and is the correct behavior for the majority of Firebase applications.

For example, here's the difference between Firebase's understanding of a user created over SAML-over-OAuth before and after we introduced this change to an existing test Firebase application:

<img width="976" alt="Screenshot 2025-01-31 at 9 55 06 AM" src="https://github.com/user-attachments/assets/efca840e-0e26-4a6d-9185-ebb152aeb506" />

Example of what developers see if they log out the Firebase credentials returned from the login flow:

<img width="931" alt="Screenshot 2025-01-31 at 9 56 15 AM" src="https://github.com/user-attachments/assets/5ca42b4c-31db-446d-9067-e06b35ad2870" />
