### PR TITLE
auth: acs: return 400 on invalid saml request IDs

### DIFF
--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -257,6 +257,10 @@ func (s *Service) samlAcs(w http.ResponseWriter, r *http.Request) {
 
 	alreadyProcessed, err := s.Store.AuthCheckAssertionAlreadyProcessed(ctx, requestID)
 	if err != nil {
+		if errors.Is(err, store.InvalidSAMLRequestID) {
+			http.Error(w, "invalid saml request id", http.StatusBadRequest)
+			return
+		}
 		panic(err)
 	}
 

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -182,6 +182,8 @@ func (s *Store) AuthGetValidateData(ctx context.Context, req *AuthGetValidateDat
 	}, nil
 }
 
+var InvalidSAMLRequestID = errors.New("invalid saml request id")
+
 func (s *Store) AuthCheckAssertionAlreadyProcessed(ctx context.Context, samlFlowID string) (bool, error) {
 	if samlFlowID == "" {
 		return false, nil
@@ -189,7 +191,7 @@ func (s *Store) AuthCheckAssertionAlreadyProcessed(ctx context.Context, samlFlow
 
 	id, err := idformat.SAMLFlow.Parse(samlFlowID)
 	if err != nil {
-		return false, err
+		return false, InvalidSAMLRequestID
 	}
 
 	ok, err := s.q.AuthCheckAssertionAlreadyProcessed(ctx, id)


### PR DESCRIPTION
This PR improves error reporting for the case where an assertion contains a malformed request ID.