### PR TITLE
Improve error message for SCIM PUT /Users/... without a userName

### DIFF
--- a/app/src/pages/ViewSCIMRequestPage.tsx
+++ b/app/src/pages/ViewSCIMRequestPage.tsx
@@ -157,7 +157,7 @@ export function ViewSCIMRequestPage() {
                 Your customer's identity provider set the SCIM{" "}
                 <code>userName</code> to be{" "}
                 <span className="font-semibold">
-                  {scimRequest.scimRequest.error.value}
+                  {scimRequest.scimRequest.error.value || "(No value)"}
                 </span>
                 , which is invalid. SSOReady requires that SCIM usernames be
                 email addresses.

--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -256,8 +256,17 @@ func (s *Service) scimUpdateUser(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	userName := resource["userName"].(string) // todo this may panic
-	active := true                            // may be omitted in request
+	if resource["userName"] == nil {
+		http.Error(w, "userName is required", http.StatusBadRequest)
+		return &badUsernameError{BadUsername: ""}
+	}
+	if _, ok := resource["userName"]; !ok {
+		http.Error(w, "userName is required", http.StatusBadRequest)
+		return &badUsernameError{BadUsername: ""}
+	}
+
+	userName := resource["userName"].(string)
+	active := true // may be omitted in request
 	if _, ok := resource["active"]; ok {
 		active = resource["active"].(bool)
 	}


### PR DESCRIPTION
This PR improves the error that is produced when SCIM clients attempt to PUT a user without a userName. They're now reported in the same way other bad usernames are:

![screenshot-2025-02-27-13-42-47](https://github.com/user-attachments/assets/dae52c2a-99de-4d2e-8ec2-3295116d3605)
