### PR TITLE
Return clearer 404 when ACSing to incorrect saml connection ID

### DIFF
--- a/internal/authservice/service.go
+++ b/internal/authservice/service.go
@@ -162,6 +162,11 @@ func (s *Service) samlAcs(w http.ResponseWriter, r *http.Request) {
 		SAMLConnectionID: samlConnID,
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrNoSuchSAMLConnection) {
+			http.Error(w, "saml connection not found", http.StatusNotFound)
+			return
+		}
+
 		var connectErr *connect.Error
 		if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeFailedPrecondition {
 			createSAMLLoginRes, err := s.Store.AuthUpsertReceiveAssertionData(ctx, &store.AuthUpsertSAMLLoginEventRequest{

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -138,6 +138,8 @@ type AuthGetValidateDataResponse struct {
 	EnvironmentAdminTestModeURL string
 }
 
+var ErrNoSuchSAMLConnection = errors.New("no such saml connection")
+
 func (s *Store) AuthGetValidateData(ctx context.Context, req *AuthGetValidateDataRequest) (*AuthGetValidateDataResponse, error) {
 	samlConnID, err := idformat.SAMLConnection.Parse(req.SAMLConnectionID)
 	if err != nil {
@@ -152,6 +154,10 @@ func (s *Store) AuthGetValidateData(ctx context.Context, req *AuthGetValidateDat
 
 	res, err := q.AuthGetValidateData(ctx, samlConnID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNoSuchSAMLConnection
+		}
+
 		return nil, fmt.Errorf("get validate data: %w", err)
 	}
 


### PR DESCRIPTION
This PR has us return a 404 with a clear error message when performing an IDP-initiated flow to a well-formed ACS URL for a nonexistent SAML connection.