### PR TITLE
Display 400, 401 SCIM request logs as "Bad request"

### DIFF
--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -570,9 +570,14 @@ function RequestsCard() {
                     {moment(scimRequest.timestamp!.toDate()).format()}
                   </TableCell>
                   <TableCell>
-                    {!scimRequest.error.case && (
-                      <Badge variant="outline">Success</Badge>
-                    )}
+                    {!scimRequest.error.case ? (
+                      scimRequest.httpResponseStatus >
+                      SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_204 ? (
+                        <Badge variant="destructive">Failed</Badge>
+                      ) : (
+                        <Badge variant="outline">Success</Badge>
+                      )
+                    ) : null}
                     {scimRequest?.error?.case === "badBearerToken" && (
                       <Badge variant="destructive">Bad bearer token</Badge>
                     )}

--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -570,16 +570,15 @@ function RequestsCard() {
                     {moment(scimRequest.timestamp!.toDate()).format()}
                   </TableCell>
                   <TableCell>
-                    {!scimRequest.error.case ? (
-                      [
+                    {!scimRequest.error.case &&
+                      ([
                         SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_400,
                         SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_401,
                       ].includes(scimRequest.httpResponseStatus) ? (
                         <Badge variant="destructive">Bad request</Badge>
                       ) : (
                         <Badge variant="outline">Success</Badge>
-                      )
-                    ) : null}
+                      ))}
                     {scimRequest?.error?.case === "badBearerToken" && (
                       <Badge variant="destructive">Bad bearer token</Badge>
                     )}

--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -571,9 +571,11 @@ function RequestsCard() {
                   </TableCell>
                   <TableCell>
                     {!scimRequest.error.case ? (
-                      scimRequest.httpResponseStatus >
-                      SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_204 ? (
-                        <Badge variant="destructive">Failed</Badge>
+                      [
+                        SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_400,
+                        SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_401,
+                      ].includes(scimRequest.httpResponseStatus) ? (
+                        <Badge variant="destructive">Bad request</Badge>
                       ) : (
                         <Badge variant="outline">Success</Badge>
                       )


### PR DESCRIPTION
This PR adapts #234 to handle 404 cases more gracefully. Credit to @RamNow for the original work this PR is based on.