### PR TITLE
scim: return 400 for bad scim user ID, not 401

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -779,7 +779,7 @@ func (s *Service) scimPatchGroup(w http.ResponseWriter, r *http.Request) error {
 			SCIMUserID: scimUserID,
 		}); err != nil {
 			if errors.Is(err, store.ErrBadSCIMUserID) {
-				http.Error(w, "bad scim user id", http.StatusUnauthorized)
+				http.Error(w, "bad scim user id", http.StatusBadRequest)
 				return nil
 			}
 


### PR DESCRIPTION
This makes for better results in the SCIM debug log, whereas 401 is used only for bad Bearer tokens today.