### PR TITLE
auth: use application/json as content-type for oauth token endpoint

### DIFF
--- a/internal/authservice/oauth.go
+++ b/internal/authservice/oauth.go
@@ -252,6 +252,7 @@ func (s *Service) oauthToken(w http.ResponseWriter, r *http.Request) {
 		TokenType:   "Bearer",
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(tokenRes); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The current Content-Type for this endpoint (text/plain) interacts poorly with Golang's x/oauth2 package, which attempts to also support form-encoded data.