### PR TITLE
feat: Support non-email usernames in SCIM

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -269,7 +269,7 @@ func (s *Service) scimCreateUser(w http.ResponseWriter, r *http.Request) error {
 
 	var domainOk bool
 	for _, domain := range allowedDomains {
-		if emailDomain == domain {
+		if emailDomain == strings.ToLower(domain) {
 			domainOk = true
 		}
 	}
@@ -371,7 +371,7 @@ func (s *Service) scimUpdateUser(w http.ResponseWriter, r *http.Request) error {
 
 	var domainOk bool
 	for _, domain := range allowedDomains {
-		if emailDomain == domain {
+		if emailDomain == strings.ToLower(domain) {
 			domainOk = true
 		}
 	}
@@ -482,7 +482,7 @@ func (s *Service) scimPatchUser(w http.ResponseWriter, r *http.Request) error {
 
 	var domainOk bool
 	for _, domain := range allowedDomains {
-		if emailDomain == domain {
+		if emailDomain == strings.ToLower(domain) {
 			domainOk = true
 		}
 	}

--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -85,9 +85,7 @@ func (s *Service) scimListUsers(w http.ResponseWriter, r *http.Request) error {
 			panic(err)
 		}
 
-		resource := scimUser.Attributes.AsMap()
-		resource["id"] = scimUser.Id
-		resource["userName"] = scimUser.Email
+		resource := scimUserToResource(scimUser)
 
 		w.Header().Set("Content-Type", "application/scim+json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/authservice/scim_test.go
+++ b/internal/authservice/scim_test.go
@@ -530,6 +530,53 @@ func TestSCIMUserFromResource(t *testing.T) {
 	}
 }
 
+func TestEmailDomainExtraction(t *testing.T) {
+	tests := []struct {
+		name           string
+		email          string
+		expectedDomain string
+		expectError    bool
+	}{
+		{
+			name:           "lowercase domain",
+			email:          "user@example.com",
+			expectedDomain: "example.com",
+			expectError:    false,
+		},
+		{
+			name:           "mixed case domain - extracted as lowercase",
+			email:          "alex@OmnifactGmbH.onmicrosoft.com",
+			expectedDomain: "omnifactgmbh.onmicrosoft.com",
+			expectError:    false,
+		},
+		{
+			name:           "uppercase domain - extracted as lowercase",
+			email:          "user@EXAMPLE.COM",
+			expectedDomain: "example.com",
+			expectError:    false,
+		},
+		{
+			name:           "subdomain with mixed case",
+			email:          "user@Mail.Example.COM",
+			expectedDomain: "mail.example.com",
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			domain, err := emailaddr.Parse(tt.email)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedDomain, domain, "Domain should be extracted as lowercase")
+			}
+		})
+	}
+}
+
 func TestEmailFormatDetection(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/authservice/scim_test.go
+++ b/internal/authservice/scim_test.go
@@ -39,6 +39,61 @@ func TestSCIMUserToResource_ManagerReference(t *testing.T) {
 			},
 		},
 		{
+			name: "realistic user with full enterprise attributes and manager",
+			input: &ssoreadyv1.SCIMUser{
+				Id:    "scim_user_6ytool3syktvl99vb3ingqzqi",
+				Email: "karstaedt@sport-thieme.de",
+				Attributes: mustNewStruct(map[string]any{
+					"active": true,
+					"displayName": "Nikolas Karstaedt",
+					"emails": []any{
+						map[string]any{
+							"primary": true,
+							"type":    "work",
+							"value":   "karstaedt@sport-thieme.de",
+						},
+					},
+					"externalId": "karstaedt",
+					"name": map[string]any{
+						"familyName": "Karstaedt",
+						"formatted":  "Nikolas Karstaedt",
+						"givenName":  "Nikolas",
+					},
+					"title": "Business Intelligence Entwickler",
+					"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+						"department": "Business Intelligence",
+						"manager":    "scim_user_cldgopimpfk79l2lwlyammhck",
+					},
+				}),
+			},
+			expected: map[string]any{
+				"id":       "scim_user_6ytool3syktvl99vb3ingqzqi",
+				"userName": "karstaedt@sport-thieme.de",
+				"active":   true,
+				"displayName": "Nikolas Karstaedt",
+				"emails": []any{
+					map[string]any{
+						"primary": true,
+						"type":    "work",
+						"value":   "karstaedt@sport-thieme.de",
+					},
+				},
+				"externalId": "karstaedt",
+				"name": map[string]any{
+					"familyName": "Karstaedt",
+					"formatted":  "Nikolas Karstaedt",
+					"givenName":  "Nikolas",
+				},
+				"title": "Business Intelligence Entwickler",
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"department": "Business Intelligence",
+					"manager": map[string]any{
+						"value": "scim_user_cldgopimpfk79l2lwlyammhck",
+					},
+				},
+			},
+		},
+		{
 			name: "already complex manager reference is preserved",
 			input: &ssoreadyv1.SCIMUser{
 				Id:    "user123",

--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -122,9 +122,17 @@ func applyOp(op Operation, obj *map[string]any) error {
 
 		subV, ok := (*current)[segment.name].(map[string]any)
 		if !ok {
-			return fmt.Errorf("invalid path: %s", op.Path)
+			// For Add operations, create intermediate objects if they don't exist
+			if opAdd {
+				newMap := make(map[string]any)
+				(*current)[segment.name] = newMap
+				current = &newMap
+			} else {
+				return fmt.Errorf("invalid path: %q", op.Path)
+			}
+		} else {
+			current = &subV
 		}
-		current = &subV
 	}
 
 	return nil

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -949,24 +949,24 @@ func TestPatch(t *testing.T) {
 				{
 					Op:    "Add",
 					Path:  "name.givenName",
-					Value: "Alex",
+					Value: "John",
 				},
 				{
 					Op:    "Add",
 					Path:  "name.familyName",
-					Value: "Augustin",
+					Value: "Doe",
 				},
 				{
 					Op:    "Add",
 					Path:  "name.formatted",
-					Value: "Alex Augustin",
+					Value: "John Doe",
 				},
 			},
 			out: map[string]any{
 				"name": map[string]any{
-					"givenName":  "Alex",
-					"familyName": "Augustin",
-					"formatted":  "Alex Augustin",
+					"givenName":  "John",
+					"familyName": "Doe",
+					"formatted":  "John Doe",
 				},
 			},
 		},
@@ -997,7 +997,7 @@ func TestPatch(t *testing.T) {
 				{
 					Op:    "Replace",
 					Path:  "name.givenName",
-					Value: "Alex",
+					Value: "John",
 				},
 			},
 			err: `invalid path: "name.givenName"`,


### PR DESCRIPTION
## Summary

This PR extends SCIM user provisioning to support non-email usernames while maintaining backward compatibility with existing implementations. It also fixes a case-sensitivity bug in email domain validation.

## Changes

### 1. Non-Email Username Support

- **Email Extraction**: Added `extractEmailFromResource()` to extract email from the `emails` array (SCIM 2.0 spec compliant)
  - Prefers email marked with `primary: true`
  - Falls back to first email if no primary specified
  - Returns error if no valid email found

- **Storage**: 
  - `userName` can now be any value (e.g., `"m.john"`, `"John"`, UUIDs, etc.)
  - Email is extracted from `emails` array and stored in the `email` column for uniqueness constraint
  - `userName` is preserved in the `attributes` JSONB field

- **Filter Optimization**: Smart filtering for `userName eq "value"` queries
  - If filter value is email format → search `email` column first (backward compatibility), fallback to `attributes`
  - If filter value is NOT email format → directly search `attributes` (skip email column for better performance)
  - `email.value eq "value"` queries continue to search only the `email` column

- **Response Format**: `scimUserToResource()` returns `userName` from attributes, fallbacks to `email` for old data

### 2. Case-Insensitive Domain Validation Fix

**Bug**: Email domain comparison was case-sensitive, causing valid requests to fail
- Example: `alex@OmnifactGmbH.onmicrosoft.com` was rejected even when `OmnifactGmbH.onmicrosoft.com` was an allowed domain
- `emailaddr.Parse()` returns lowercase domains, but allowed domains from DB kept original casing

**Fix**: Lowercase allowed domains before comparison
if emailDomain == strings.ToLower(domain) {
    domainOk = true
}
